### PR TITLE
Add Pico, a blazing fast, flat file CMS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ A curated list of amazingly awesome PHP libraries, resources and shiny things.
 *Modern content management systems.*
 
 * [Bolt](https://github.com/bolt/bolt) - A simple CMS built with Silex and Twig.
+* [Pico](https://github.com/gilbitron/Pico) - A stupidly simple, blazing fast, flat file CMS.
 
 ## Templating
 *Libraries and tools for templating and lexing.*


### PR DESCRIPTION
Pico is a stupidly simple, blazing fast, flat file CMS.

**GitHub:** https://github.com/gilbitron/Pico
**Website:** http://pico.dev7studios.com/
**Documentation:** http://pico.dev7studios.com/docs.html

Pico was made by @gilbitron from @Dev7studios. Released under the MIT license.
