### PR TITLE
CakePHP and FuelPHP added to the frameworks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A curated list of amazingly awesome PHP libraries, resources and shiny things.
 * [Lithium](http://li3.me/) - Another framework of components.
 * [Aura PHP](http://auraphp.com/) - A framework of independent components.
 * [Phalcon](http://phalconphp.com/en/) - A framework implemented as a C extension.
-* [CakePHP](http://cakephp.org) - Another rapid development framework.
+* [CakePHP](http://cakephp.org) - MVC rapid development framework.
 * [FuelPHP](http://fuelphp.com) - Another framework comprised of components.
 
 ## Framework Components


### PR DESCRIPTION
I've added some more PHP frameworks to the list. Let me know if their descriptions needs to be fixed in more details. Thanks.
