### PR TITLE
Add Drest to the REST and API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ A curated list of amazingly awesome PHP libraries, resources and shiny things.
 * [Hateoas](https://github.com/willdurand/Hateoas) - A HATEOAS REST web service library.
 * [HAL](https://github.com/blongden/hal) - A Hypertext Application Language (HAL) builder library.
 * [Negotiation](https://github.com/willdurand/Negotiation) - A content negotiation library.
+* [Drest](https://github.com/leedavis81/drest) - Quickly and easily expose Doctrine entities as REST resource endpoints.
 
 ## Caching
 *Libraries for caching data.*


### PR DESCRIPTION
Added Drest under the Rest and API section. More details on this tool can be found here: http://leedavis81.github.io/drest/
