### PR TITLE
Adds PHPTAL as templating library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ A curated list of amazingly awesome PHP libraries, resources and shiny things.
 * [Mustache](https://github.com/bobthecow/mustache.php) - A PHP implementation of the Mustache template language.
 * [Phly Mustache](https://github.com/weierophinney/phly_mustache) - Another PHP implementation of the Mustache template language.
 * [MtHaml](https://github.com/arnaud-lb/MtHaml) - A PHP implementation of the HAML template language.
+* [PHPTAL](http://phptal.org/) - A PHP implementation of the TAL templating language, orignating from the Python Zope library.
 * [Plates](http://platesphp.com/) - A native PHP templating library.
 * [Lex](https://github.com/pyrocms/lex) - A lightweight template parser.
 


### PR DESCRIPTION
The [TAL language is described on wikipedia](http://en.wikipedia.org/wiki/Template_Attribute_Language).

I think TAL is a widely enough accepted standard to warrant the addition of a PHP implementation to the list of awesomeness.

Usage of TAL in Twig is also available through a plugin called [Twital](https://github.com/goetas/twital), although I am unsure if I should also suggest this for inclusion on the list.
