### PR TITLE
Add CssToInlineStyles to Email section

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ A curated list of amazingly awesome PHP libraries, resources and shiny things.
 * [Fetch](https://github.com/tedivm/Fetch) - An IMAP library.
 * [Email Reply Parser](https://github.com/willdurand/EmailReplyParser) - An email reply parser library.
 * [Stampie](https://github.com/henrikbjorn/Stampie) - A library for email services such as [SendGrid](http://sendgrid.com), [PostMark](http://postmarkapp.com), [MailGun](http://www.mailgun.com) and [Mandrill](http://www.mandrill.com).
+* [CssToInlineStyles](https://github.com/tijsverkoyen/CssToInlineStyles) - A library to inline CSS in email templates.
 
 ## Files
 *Libraries for file manipulation and MIME type detection.*


### PR DESCRIPTION
Added https://github.com/tijsverkoyen/CssToInlineStyles, useful for inlining CSS so it works in more email clients.
