### PR TITLE
Added Yii to Frameworks Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ A curated list of amazingly awesome PHP libraries, resources and shiny things.
 * [Laravel 4](http://laravel.com/) - A simple PHP framework.
 * [Aura PHP](http://auraphp.com/) - A framework of independent components.
 * [Phalcon](http://phalconphp.com/en/) - A framework implemented as a C extension.
+* [Yii](http://www.yiiframework.com/) - A high-performance PHP framework best for developing Web 2.0 applications.
 
 ## Framework Extras
 *Extras related to web development frameworks.*


### PR DESCRIPTION
I felt that Yii Framework was missing from the list. After extensive search for a robust framework we've chosen Yii Framework, and have not looked back since. 

The reason why it should be in awesome-php is that it's very logically structured, it has a growing community (at least in London), and with a new version round the corner it's only going to become more popular. 
