### PR TITLE
Added link to Gantti (A simple PHP Gantt Class)

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ A curated list of amazingly awesome PHP libraries, resources and shiny things.
 * [Country List](https://github.com/umpirsky/country-list) - A list of all countries with names and ISO 3166-1 codes.
 * [PHP-GPIO](https://github.com/ronanguilloux/php-gpio) - A library for playing with the Raspberry PI's GPIO pins.
 * [print_o](https://github.com/koriym/print_o) - An object graph visualizer.
+* [Gantti](https://github.com/bastianallgeier/gantti) - A simple PHP Gantt Class.
 
 # Software
 *Software for creating a development environment.*


### PR DESCRIPTION
Added link to Gantti (A simple PHP Gantt Class) in the Miscellaneous section. Though this project's repository has not been commited to since Oct 4, 2012, I still believe this tool is worth including in this list because when I searched packagist (https://packagist.org/search/?q=gantt) using the keyword "gantt", there were only two results (one of which is a link to a gantti repository that cannot be found). Hopefully https://github.com/bastianallgeier/gantti does not later become a dead link. Would it be acceptable if I put the link to the project's homepage (http://bastianallgeier.com/gantti/) instead?
