### PR TITLE
Added Prophecy

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ A curated list of amazingly awesome PHP libraries, resources and shiny things.
 * [Atoum](https://github.com/atoum/atoum) - A simple testing library.
 * [Mockery](https://github.com/padraic/mockery) - A mock object library for testing.
 * [Phake](https://github.com/mlively/Phake) - Another mock object library for testing.
+* [Prophecy](https://github.com/phpspec/prophecy) - Highly opinionated mocking framework for PHP 5.3+.
 * [Faker](https://github.com/fzaninotto/Faker) - A fake data generator library.
 * [Samsui](https://github.com/mauris/samsui) - Another fake data generator library.
 * [Alice](https://github.com/nelmio/alice) - An expressive fixture generation library.


### PR DESCRIPTION
Prophecy is a highly opinionated yet very powerful and flexible PHP object mocking framework. 

It's used as mocking framework in [PHPSpec](https://github.com/phpspec/phpspec) and will eventually be supported by [PHPUnit](https://github.com/sebastianbergmann/phpunit) (see: https://github.com/sebastianbergmann/phpunit/commit/6c21c66567031c863f207fb46b3c1c545d5589d1).
