### PR TITLE
Added Simply Random as random numbers generating alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 
 * [HTML Purifier](https://github.com/ezyang/htmlpurifier) - A standards compliant HTML filter.
 * [RandomLib](https://github.com/ircmaxell/RandomLib) - A library for generating random numbers and strings.
+* [Simply Random](https://github.com/blocktrail/simply-random-php) - A library for generating random numbers and strings using MCRYPT_DEV_URANDOM.
 * [True Random](https://github.com/pixeloution/true-random) - A library that generates random numbers using [www.random.org](http://www.random.org/).
 * [SecurityMultiTool](https://github.com/padraic/SecurityMultiTool) - A PHP security library.
 * [PHPSecLib](http://phpseclib.sourceforge.net/) - A pure PHP secure communications library.


### PR DESCRIPTION
Very simple library that only uses MCRYPT_DEV_URANDOM, which is 'the right thing to do' instead of all the libs that go and do their own custom mixing of various other libs.

see:
http://timoh6.github.io/2013/11/05/Secure-random-numbers-for-PHP-developers.html

and more:
https://news.ycombinator.com/item?id=6216101
http://security.stackexchange.com/questions/3936/is-a-rand-from-dev-urandom-secure-for-a-login-key/3939#3939