### PR TITLE
add AFUP Youtube channel in the PHP Videos section

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,7 @@ Various resources, such as books, websites and articles, for improving your PHP 
 * [Taking PHP Seriously](http://www.infoq.com/presentations/php-history) - A talk outlining PHP's strengths by Keith Adams of Facebook.
 * [PHP Town Hall](http://phptownhall.com/) - A casual PHP podcast by Ben Edmunds and Phil Sturgeon.
 * [Programming with Anthony](http://www.youtube.com/playlist?list=PLM-218uGSX3DQ3KsB5NJnuOqPqc5CW2kW) - A video series by Anthony Ferrara.
+* [AFUP Youtube Channel](https://www.youtube.com/user/afupPHP) - Videos of talks given in the Forum PHP and PHPTour conferences (mostly in french)
 
 ## PHP Reading
 *PHP-releated reading materials.*


### PR DESCRIPTION
it contains a lot of talks given during the PHPTour and ForumPHP conferences. Some of the talks are in english, but they are mostly in french.