### PR TITLE
Add Stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [PHPDBG](http://phpdbg.com/) - An interactive PHP debugger.
 * [Tracy](https://github.com/nette/tracy) - A simple error detection, logging and time measuring library.
 * [Z-Ray](http://www.zend.com/en/products/server/z-ray) - A debug and profile tool for Zend Server.
+* [Stop](https://github.com/ivoba/stop) - Lightweight Dumper with infos like File, Line & Memory.
 
 ## Build Tools
 *Project build and automation tools.*


### PR DESCRIPTION
https://github.com/ivoba/stop

Stop is a lightweight Dumper for PHP 5.3+

* shortcut functions
* some more infos as File, Line & Memory
* some nicer rendering with Twitter Bootstrap,
* options for return or continue & hide which will print to javascript console
*disable Stop for prod env
* autoloading
* extensibility, if youd like to use jqueryUI f.e just subclass the Dumper and set the class
* context awareness: if you are in console it will render in text mode, if in ajax mode it will render in json mode
* dumper for json strings
* stop_type as a better version of var_dump(get_class($var));exit;
