### PR TITLE
[routers] TimeToogo/RapidRoute

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Route](https://github.com/thephpleague/route) - A routing library built on top of Fast Route.
 * [Pux](https://github.com/c9s/Pux) - Another fast routing library.
 * [Klein](https://github.com/chriso/klein.php) - A flexible router.
+* [RapidRoute](https://github.com/TimeToogo/RapidRoute) - Another fast router library.
 
 ## Templating
 *Libraries and tools for templating and lexing.*


### PR DESCRIPTION
You can find the benchmarks [here](https://github.com/TimeToogo/RapidRoute#benchmarks).