### PR TITLE
[pdf] tecnickcom/TCPDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Snappy](https://github.com/KnpLabs/snappy) - A PDF and image generation library.
 * [WKHTMLToPDF](https://github.com/antialize/wkhtmltopdf) - A tool to convert HTML to PDF.
 * [PHPPdf](https://github.com/psliwa/PHPPdf) - A library for generating PDFs and images from XML.
+* [TCPDF](https://github.com/tecnickcom/TCPDF) - A library to generate PDF documents and barcodes
 
 ## Office
 *Libraries for working with office suite documents.*


### PR DESCRIPTION
TCPDF, a library to generate PDF documents and barcodes. An official site is at http://www.tcpdf.org/ and official git clone is at https://github.com/tecnickcom/TCPDF.