### PR TITLE
Fixed the PHP-DI entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Pimple](http://pimple.sensiolabs.org/) - A tiny dependency injection container.
 * [Auryn](https://github.com/rdlowrey/Auryn) - Another dependency injection container.
 * [Container](https://github.com/thephpleague/container) - Another flexible dependency injection container.
-* [PHP DI](http://mnapoli.github.com/PHP-DI/) - A dependency injection implementation using annotations.
+* [PHP-DI](http://php-di.org/) - A dependency injection container supporting autowiring and PHP configuration.
 * [Acclimate](https://github.com/jeremeamia/acclimate) - A common interface to dependency injection containers and service locators.
 * [Symfony DI](https://github.com/symfony/DependencyInjection) - A dependency injection container component (SF2).
 


### PR DESCRIPTION
Hi there, thank you for mentioning PHP-DI. I have updated the entry:

- the name is PHP-DI (instead of PHP DI)
- updated the URL (http://php-di.org/)
- updated the description (annotations have become a secondary feature and are encompassed by "autowiring")

Please let me know if there's anything to change. If you want I can replace the description with a more generic "Another dependency injection container", it would still be better than mentioning annotations.