### PR TITLE
Added zend-diactoros and updated middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,13 +175,15 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [HTTPFul](https://github.com/nategood/httpful) - A chainable HTTP client.
 * [Goutte](https://github.com/fabpot/Goutte) - A simple web scraper.
 * [PHP VCR](http://php-vcr.github.io/) - A library for recording and replaying HTTP requests.
+* [zend-diactoros](https://github.com/zendframework/zend-diactoros) - PSR-7 HTTP Message implementation.
 
 ## Middlewares
 *Libraries for building application using middlewares.*
 
 * [Stack](https://github.com/stackphp) - A library of stackable middleware for Silex/Symfony.
 * [Slim Middleware](https://github.com/codeguy/Slim-Middleware) - A collection of custom middleware for Slim.
-* [Conduit](https://github.com/phly/conduit) - A port of [Sencha Connect](https://github.com/senchalabs/connect) to PHP.
+* [zend-stratigility](https://github.com/zendframework/zend-stratigility) - A port of [Sencha Connect](https://github.com/senchalabs/connect) to PHP.
+* [Relay](https://github.com/relayphp/Relay.Relay) - A PSR-7 middleware dispatcher.
 
 ## URL
 *Libraries for parsing URLs.*


### PR DESCRIPTION
* I have added `zend-diactoros` which is probably the best PSR-7 implementation.
* Conduit has been deprecated in favour of zend-stratigility.
* Relay looks like a promising PSR-7 middleware dispatcher.

I am surprised that there is not much in here about PSR-7.