### PR TITLE
Removal of Sentry Social and add Sentry replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ Libraries to help manage database schemas and migrations.
 ## Authentication and Authorization
 *Libraries for implementing user authentication and authorization.*
 
-* [Sentry](https://github.com/cartalyst/sentry) - A framework agnostic authentication & authorisation library.
+* [Sentinel](https://github.com/cartalyst/sentinel) - A framework agnostic authentication & authorisation library.
 * [Opauth](https://github.com/opauth/opauth) - A multi-provider authentication framework.
 * [OAuth2 Server](http://oauth2.thephpleague.com/) - An OAuth2 authentication server, resource server and client library.
 * [OAuth2 Server](http://bshaffer.github.io/oauth2-server-php-docs/) - Another OAuth2 server implementation.

--- a/README.md
+++ b/README.md
@@ -525,7 +525,6 @@ Libraries to help manage database schemas and migrations.
 *Libraries for implementing user authentication and authorization.*
 
 * [Sentry](https://github.com/cartalyst/sentry) - A framework agnostic authentication & authorisation library.
-* [Sentry Social](http://docs.cartalyst.com/sentry-social-2/introduction) - A library for social network authentication.
 * [Opauth](https://github.com/opauth/opauth) - A multi-provider authentication framework.
 * [OAuth2 Server](http://oauth2.thephpleague.com/) - An OAuth2 authentication server, resource server and client library.
 * [OAuth2 Server](http://bshaffer.github.io/oauth2-server-php-docs/) - Another OAuth2 server implementation.


### PR DESCRIPTION
Sentry Social now links to a page with a status code of 404 so this link has been removed.

As stated on the Sentry repository

> This package is DEPRECATED, please check our [Sentinel](https://github.com/cartalyst/sentinel) package for a better authentication & authorization system.