### PR TITLE
Replace thephpleague/url with thephpleague/uri.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 *Libraries for parsing URLs.*
 
 * [Purl](https://github.com/jwage/purl) - A URL manipulation library.
+* [Uri](https://github.com/thephpleague/uri) - A URL manipulation Library.
 * [PHP Domain Parser](https://github.com/jeremykendall/php-domain-parser) - A domain suffix parser library.
-* [Url](https://github.com/thephpleague/url) - A simple URL manipulation library.
 
 ## Email
 *Libraries for sending and parsing email.*


### PR DESCRIPTION
League\Url 3 is EOL since 2015-09-23