### PR TITLE
Added `check_php` nagios plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,7 @@ Libraries to help manage database schemas and migrations.
 *Infrastructure for providing PHP applications and services.*
 
 * [appserver.io](http://appserver.io/) - A multithreaded application server for PHP, written in PHP.
+* [check_php](https://github.com/cytopia/check_php) - Nagios plugin to check for PHP updates, startup errors, missing modules, etc.
 
 # Resources
 Various resources, such as books, websites and articles, for improving your PHP development skills and knowledge.


### PR DESCRIPTION
A nagios plugin that checks PHP setups against the following:

* Check for PHP startup errors
* Check for PHP updates (inside minor versions and patch levels)
* Check for missing PHP modules
* Check for blacklisted PHP modules and throw err/warn if they are compiled in
* Check for expected php.ini config directives (e.g.: date.timezone must be "Europe/Berlin", etc)
* Each check can specify its own severity (warning or error)