### PR TITLE
Suggest Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ Libraries to help manage database schemas and migrations.
 * [UA Parser](https://github.com/tobie/ua-parser/tree/master/php) - A library for parsing user agent strings.
 * [Device Detector](https://github.com/piwik/device-detector) - Another library for parsing user agent strings.
 * [Mobile-Detect](https://github.com/serbanghita/Mobile-Detect) - A lightweight PHP class for detecting mobile devices (including tablets).
+* [Agent](https://github.com/jenssegers/agent) - A PHP desktop/mobile user agent parser, based on Mobiledetect.
 
 ## Numbers
 *Libraries for working with numbers.*


### PR DESCRIPTION
The Agent library starts where MobileDetects ends. It adds desktop support to the existing MobileDetect library.