### PR TITLE
Update Doctrine Extensions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 *Libraries for interacting with databases using object-relational mapping (ORM) or datamapping techniques.*
 
 * [Doctrine](http://www.doctrine-project.org/) - A comprehensive DBAL and ORM.
-* [Doctrine Extensions](https://github.com/l3pp4rd/DoctrineExtensions) - A collection of Doctrine behavioural extensions.
+* [Doctrine Extensions](https://github.com/Atlantic18/DoctrineExtensions) - A collection of Doctrine behavioural extensions.
 * [Propel](http://propelorm.org/) - A fast ORM, migration library and query builder.
 * [Eloquent](https://github.com/illuminate/database) - A simple ORM (L5).
 * [LazyRecord](https://github.com/c9s/LazyRecord) - A fast ORM designed for simplicity, extendability and performance.


### PR DESCRIPTION
The project moved from https://github.com/l3pp4rd/DoctrineExtensions to https://github.com/Atlantic18/DoctrineExtensions