### PR TITLE
Add new PHP websites and podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -906,6 +906,7 @@ Various resources, such as books, websites and articles, for improving your PHP 
 * [PHP UK Conference](https://www.youtube.com/user/phpukconference/videos) - A collection of videos from the PHP UK Conference.
 * [Programming with Anthony](https://www.youtube.com/playlist?list=PLM-218uGSX3DQ3KsB5NJnuOqPqc5CW2kW) - A video series by Anthony Ferrara.
 * [Taking PHP Seriously](https://www.infoq.com/presentations/php-history) - A talk outlining PHP's strengths by Keith Adams of Facebook.
+* [Voice of the ElePHPant](https://voicesoftheelephpant.com/) - Interviews with members of PHP community.
 
 ## PHP Reading
 *PHP-releated reading materials.*

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
     - [PHP Websites](#php-websites)
     - [Other Websites](#other-websites)
     - [PHP Books](#php-books)
-    - [PHP Videos](#php-videos)
+    - [PHP Podcasts and Videos](#php-podcasts-and-videos)
     - [PHP Reading](#php-reading)
     - [PHP Internals Reading](#php-internals-reading)
 - [Contributing](#contributing)
@@ -899,8 +899,8 @@ Various resources, such as books, websites and articles, for improving your PHP 
 * [Understanding Computation](http://computationbook.com) - A book about computation theory by Tom Stuart.
 * [Vagrant Cookbook](https://leanpub.com/vagrantcookbook) - A book about creating Vagrant environments by Erika Heidi.
 
-## PHP Videos
-*Fantastic PHP-related videos.*
+## PHP Podcasts and Videos
+*Fantastic PHP-related podcasts and videos.*
 
 * [PHP Town Hall](https://phptownhall.com/) - A casual PHP podcast by Ben Edmunds and Phil Sturgeon.
 * [PHP UK Conference](https://www.youtube.com/user/phpukconference/videos) - A collection of videos from the PHP UK Conference.

--- a/README.md
+++ b/README.md
@@ -865,6 +865,7 @@ Various resources, such as books, websites and articles, for improving your PHP 
 
 * [Atlassian Git Tutorials](https://www.atlassian.com/git/) - A series of Git tutorials.
 * [Hg Init](http://hginit.com/) - A series of Mercurial tutorials.
+* [Learning Linux](https://linuxjourney.com/) - A website for learning Linux.
 * [Semantic Versioning](http://semver.org/) - A website explaining semantic versioning.
 * [Servers for Hackers](https://serversforhackers.com/) - A newsletter about server management.
 * [The Open Web Application Security Project (OWASP)](https://www.owasp.org/index.php/Main_Page) - An open software security community.

--- a/README.md
+++ b/README.md
@@ -859,6 +859,7 @@ Various resources, such as books, websites and articles, for improving your PHP 
 * [PHPTrends](http://phptrends.com/) - An overview of fastest growing PHP libraries.
 * [Securing PHP](http://securingphp.com/) - A newsletter about PHP security and library recommendations.
 * [Seven PHP](http://7php.com/) - A website that interviews members of the PHP community.
+* [PHP Annotated Monthly](https://blog.jetbrains.com/phpstorm/category/php-annotated-monthly/) - A monthly digest of PHP news.
 
 ## Other Websites
 *Useful websites related to web development.*

--- a/README.md
+++ b/README.md
@@ -908,7 +908,7 @@ Various resources, such as books, websites and articles, for improving your PHP 
 * [PHP UK Conference](https://www.youtube.com/user/phpukconference/videos) - A collection of videos from the PHP UK Conference.
 * [Programming with Anthony](https://www.youtube.com/playlist?list=PLM-218uGSX3DQ3KsB5NJnuOqPqc5CW2kW) - A video series by Anthony Ferrara.
 * [Taking PHP Seriously](https://www.infoq.com/presentations/php-history) - A talk outlining PHP's strengths by Keith Adams of Facebook.
-* [Voice of the ElePHPant](https://voicesoftheelephpant.com/) - Interviews with members of PHP community.
+* [Voices of the ElePHPant](https://voicesoftheelephpant.com/) - Interviews with members of PHP community.
 
 ## PHP Reading
 *PHP-releated reading materials.*

--- a/README.md
+++ b/README.md
@@ -937,8 +937,8 @@ Various resources, such as books, websites and articles, for improving your PHP 
 * [Understanding Computation](http://computationbook.com) - A book about computation theory by Tom Stuart.
 * [Vagrant Cookbook](https://leanpub.com/vagrantcookbook) - A book about creating Vagrant environments by Erika Heidi.
 
-## PHP Podcasts and Videos
-*Fantastic PHP-related podcasts and videos.*
+## PHP Videos
+*Fantastic PHP-related videos.*
 
 * [Nomad PHP Lightning Talks](https://www.youtube.com/c/nomadphp) - 10 to 15 minute Lightning Talks by PHP community members.
 * [PHP UK Conference](https://www.youtube.com/user/phpukconference/videos) - A collection of videos from the PHP UK Conference.
@@ -947,7 +947,7 @@ Various resources, such as books, websites and articles, for improving your PHP 
 * [Voices of the ElePHPant](https://voicesoftheelephpant.com/) - Interviews with members of PHP community.
 
 ## PHP Podcasts
-*Podcasts with a main focus on PHP topics*
+*Podcasts with a focus on PHP topics.*
 
 * [PHP Town Hall](https://phptownhall.com/) - A casual PHP podcast by Ben Edmunds and Phil Sturgeon.
 * [Voices of the ElePHPant](https://voicesoftheelephpant.com/) Interviews with the people that make the PHP community special.

--- a/README.md
+++ b/README.md
@@ -903,7 +903,7 @@ Various resources, such as books, websites and articles, for improving your PHP 
 *Fantastic PHP-related podcasts and videos.*
 
 * [PHP Roundtable](https://www.phproundtable.com/) - A PHP podcast.
-* [PHP Town Hall](https://phptownhall.com/) - A casual PHP podcast by Ben Edmunds and Phil Sturgeon.
+* [PHP Town Hall](https://phptownhall.com/) - Another PHP podcast.
 * [PHP UK Conference](https://www.youtube.com/user/phpukconference/videos) - A collection of videos from the PHP UK Conference.
 * [Programming with Anthony](https://www.youtube.com/playlist?list=PLM-218uGSX3DQ3KsB5NJnuOqPqc5CW2kW) - A video series by Anthony Ferrara.
 * [Taking PHP Seriously](https://www.infoq.com/presentations/php-history) - A talk outlining PHP's strengths by Keith Adams of Facebook.

--- a/README.md
+++ b/README.md
@@ -902,6 +902,7 @@ Various resources, such as books, websites and articles, for improving your PHP 
 ## PHP Podcasts and Videos
 *Fantastic PHP-related podcasts and videos.*
 
+* [PHP Roundtable](https://www.phproundtable.com/) - A PHP podcast.
 * [PHP Town Hall](https://phptownhall.com/) - A casual PHP podcast by Ben Edmunds and Phil Sturgeon.
 * [PHP UK Conference](https://www.youtube.com/user/phpukconference/videos) - A collection of videos from the PHP UK Conference.
 * [Programming with Anthony](https://www.youtube.com/playlist?list=PLM-218uGSX3DQ3KsB5NJnuOqPqc5CW2kW) - A video series by Anthony Ferrara.


### PR DESCRIPTION
I've added these links: 
- Linux Journey: https://linuxjourney.com/
- PHP Roundtable: https://www.phproundtable.com/
- Voices of the ElePHPant: https://voicesoftheelephpant.com/
- PHP Annotated Monthly: https://blog.jetbrains.com/phpstorm/category/php-annotated-monthly/

I've also renamed a category and done a little description cleanup.
