### PR TITLE
Add metaphore (cache slam defense library).

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,7 @@ Libraries to help manage database schemas and migrations.
 * [CacheTool](https://github.com/gordalina/cachetool) - A tool to clear APC/opcode caches from the command line.
 * [Cake Cache](https://github.com/cakephp/cache) - A caching library (CP).
 * [Doctrine Cache](https://github.com/doctrine/cache) - A caching library.
+* [Metaphore](https://github.com/sobstel/metaphore) - Cache slam defense using a semaphore to prevent dogpile effect.
 * [Stash](https://github.com/tedious/Stash) - Another library for caching.
 * [Zend Cache](https://github.com/zendframework/zend-cache) - Another caching library (ZF2).
 


### PR DESCRIPTION
Unique cache library to prevent a dogpile effect. 

It's complimentary solution to standard regular caching library (not replacement) for frequently requested and long running queries/code/etc.

Widely used in the wild for high-traffic websites like soccerway.com or goal.com.

More details: http://highscalability.com/blog/2014/7/30/preventing-the-dogpile-effect-problem-and-solution.html