### PR TITLE
[Micro Frameworks] Add Fat-free Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Proton](https://github.com/alexbilbie/Proton) - A StackPHP compatible micro framework.
 * [Silex](http://silex.sensiolabs.org/) - A micro framework built around Symfony2 components.
 * [Slim](http://www.slimframework.com/) - Another simple micro framework.
+* [Fat-Free Framework](https://fatfreeframework.com) - Lightweight micro-framework.
 
 ## Micro Framework Extras
 *Extras related to micro frameworks and routers.*


### PR DESCRIPTION
Fat-free framework is minimalist framework with SQL and NoSQL support, their own Flat-File DB called Jig, Data mappers, Image processor, Template engine, On-the-fly Javascript/CSS compressor.

Web: https://fatfreeframework.com/home
Github: https://github.com/bcosca/fatfree
Documentation: https://fatfreeframework.com/api-reference
Lisence: GNU Public License (GPL v3)
