### PR TITLE
Add Dontbug reverse debugger to Debugging/Profiling tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [APM](http://pecl.php.net/package/APM) - Monitoring extension collecting errors and statistics into SQLite/MySQL/StatsD.
 * [Barbushin PHP Console](https://github.com/barbushin/php-console) - Another web debugging console using Google Chrome.
 * [Blackfire.io](https://blackfire.io) - A low-overhead code profiler.
+* [Dontbug](https://github.com/sidkshatriya/dontbug) - A reverse debugger for PHP.
 * [Kint](https://github.com/raveren/kint) - A debugging and profiling tool.
 * [PHP Console](https://github.com/Seldaek/php-console) - A web debugging console.
 * [PHP Debug Bar](http://phpdebugbar.com/) - A debugging toolbar.


### PR DESCRIPTION
Request addition of [Dontbug](https://github.com/sidkshatriya/dontbug) reverse debugger to the Awesome PHP list. 

> Dontbug is a reverse debugger (aka time travel debugger) for PHP. It allows you to record the execution of PHP scripts (in command line mode or in the browser) and replay the same execution back in a PHP IDE debugger. During replay you may debug normally (forward mode debugging) or in reverse, which allows you to step over/out backwards, step backwards, run backwards, run to cursor backwards, set breakpoints in the past and so forth.
