### PR TITLE
Remove deprecated assetic from the recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,6 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 ## Asset Management
 *Tools for managing, compressing and minifying website assets.*
 
-* [Assetic](https://github.com/kriswallsmith/assetic) - An asset manager pipeline library.
 * [JShrink](https://github.com/tedious/JShrink) - A JavaScript minifier library.
 * [Munee](https://github.com/meenie/munee) - An asset optimiser library.
 * [Pipe](https://github.com/CHH/pipe) - Another asset manager pipeline library.


### PR DESCRIPTION
Remove assetic from the recommendations because its maintainers marked it as deprecated.
See https://github.com/kriswallsmith/assetic/issues/79#issuecomment-266771392 for the details.