### PR TITLE
Update Sylius description

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Payum](https://github.com/payum/payum) - A payment abstraction library.
 * [Shopware](https://github.com/shopware/shopware) - Highly customizable e-commerce software
 * [Swap](https://github.com/florianv/swap) - An exchange rates library.
-* [Sylius](http://sylius.org/) - An open source e-commerce solution.
+* [Sylius](http://sylius.org/) - Open source e-commerce framework, consisting of standalone components and bundles as glue.
 
 ## PDF
 *Libraries and software for working with PDF files.*


### PR DESCRIPTION
.. as it is seen as non-monolith framework consisting of standalone PHP components, that use Symfony bundles to glue all of that together.

Arguments for changing it like this is this component-based approach is a more explicit description, and fills a gap for developers.