### PR TITLE
Hey Travis, SSL errors are allowed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --white-list igor.io,symfony,toranproxy.com
+  - awesome_bot README.md --allow-ssl --white-list igor.io,symfony,toranproxy.com
 notifications:
   email: false


### PR DESCRIPTION
Recently our builds are always failing by a following link.

```
Issues :-(
> Links 
  1. [L929]  https://voicesoftheelephpant.com/ SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed 
> Dupes 
  None ✓
```