### PR TITLE
Include Opulence in the list of frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [CakePHP](https://cakephp.org/) - A rapid application development framework (CP).
 * [Laravel 5](https://laravel.com/) - Another PHP framework (L5).
 * [Nette](https://nette.org) - Another framework comprised of individual components.
+* [Opulence](https://www.opulencephp.com/) - A simple, secure, and scalable PHP application framework.
 * [Phalcon](https://phalconphp.com/en/) - A framework implemented as a C extension.
 * [PPI Framework 2](http://www.ppi.io) - An interoperability framework.
 * [Symfony](https://symfony.com/) - A framework comprised of individual components (SF).


### PR DESCRIPTION
Probably, the first PHP7 specific framework. While, I linked the website URL in the pull request, the development is done here in Github at https://github.com/opulencephp/Opulence .

I am unsure, if it should be considered new. While the version 1.0 was released on Dec 6, 2016, it was in development with active feedback from the community much earlier. Here are some critical reviews... https://www.reddit.com/r/PHP/comments/4p2mjc/new_fullstack_php_7_framework_opulence/ .

As per the author of this framework, it's kind of a bridge between Symfony's modularity and Laravel's syntax.

About me:

I have no affiliation with this framework. I am actually new to any framework. Never worked on any framework. Wanted to start with one that is written specific to PHP7. And found it today. So, I found this awesome-php list too! Been a WordPress guy for years. Missed many things in PHP. So, going back to the basics now.

Comments welcome!