### PR TITLE
Remove Icicle from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,6 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Event](https://github.com/thephpleague/event) - An event library with a focus on domain events.
 * [Hoa EventSource](https://github.com/hoaproject/Eventsource) - An event source library.
 * [Hoa WebSocket](https://github.com/hoaproject/Websocket) - Another web socket library.
-* [Icicle](https://github.com/icicleio/icicle) - An asynchronous library with coroutines, non-blocking I/O, and multithreading.
 * [Prooph Event Store](https://github.com/prooph/event-store) - An event source component to persist event messages
 * [Ratchet](https://github.com/ratchetphp/Ratchet) - A web socket library.
 * [React](https://github.com/reactphp/react) - An event driven non-blocking I/O library.


### PR DESCRIPTION
Icicle is deprecated as per the repository readme file.