### PR TITLE
remove shunt, it's been marked as abandoned

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,6 @@ Libraries to help manage database schemas and migrations.
 * [Pecan](https://github.com/mcrumm/pecan) - An event-driven, non-blocking shell.
 * [PsySH](https://github.com/bobthecow/psysh) - Another PHP REPL.
 * [ShellWrap](https://github.com/MrRio/shellwrap) - A simple command line wrapper library.
-* [Shunt](https://github.com/thephpleague/shunt) - A library for running commands in parallel on multiple remote machines.
 
 ## Authentication and Authorization
 *Libraries for implementing user authentication and authorization.*


### PR DESCRIPTION
primary source, github description: https://github.com/thephpleague/shunt
secondary source: no longer listed on https://thephpleague.com/#packages