### PR TITLE
Add Siler

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Radar](https://github.com/radarphp/Radar.Adr) - An Action-Domain-Responder implementation for PHP.
 * [Silex](http://silex.sensiolabs.org/) - A micro framework built around Symfony components.
 * [Slim](https://www.slimframework.com/) - Another simple micro framework.
+* [Siler](https://github.com/leocavalcante/siler) - A micro framework primarily based on PHP functions and files instead of classes.
 
 ## Micro Framework Extras
 *Extras related to micro frameworks and routers.*


### PR DESCRIPTION
Despite it isn't popular as Slim, Silex and Lumen, it is getting closer to Bullet and Proton.
But the main reason IMHO to get Siler listed is about its uniqueness approach on how PHP micro frameworks, libraries and web applications are made.
It proposes plain old functions and files over classes in a nice structured, PSR compilant and well tested way.