### PR TITLE
Add BotMan

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,6 +762,7 @@ Libraries to help manage database schemas and migrations.
 *Useful libraries or tools that don't fit in the categories above.*
 
 * [Annotations](https://github.com/doctrine/annotations) - An annotations library (part of Doctrine).
+* [BotMan](https://github.com/mpociot/botman) - A framework agnostic PHP library to build cross-platform chat bots.
 * [Cake Utility](https://github.com/cakephp/utility) - Utility classes such as Inflector, String, Hash, Security and Xml (CP).
 * [Chief](https://github.com/adamnicholson/Chief) - A command bus library.
 * [ClassPreloader](https://github.com/ClassPreloader/ClassPreloader) - A library for optimising autoloading.


### PR DESCRIPTION
BotMan is a framework agnostic PHP library to build chatbots for multiple messaging services using only one codebase, with support for natural language processing tools. Right now, BotMan supports 7 messaging services out of the box:

- Slack
- Telegram
- Microsoft Bot Framework
- Nexmo
- HipChat
- Facebook Messenger
- WeChat

It also has an easy to use, expressive API and allows users to write their own messaging service drivers or middleware components.

The documentation for BotMan can be found at https://botman.io