### PR TITLE
Add new lib to debug session

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [APM](http://pecl.php.net/package/APM) - Monitoring extension collecting errors and statistics into SQLite/MySQL/StatsD.
 * [Barbushin PHP Console](https://github.com/barbushin/php-console) - Another web debugging console using Google Chrome.
 * [Blackfire.io](https://blackfire.io) - A low-overhead code profiler.
+* [Dephpugger](https://github.com/tacnoman/dephpugger) - Debug with breakpoints to run in terminal without IDE.
 * [Kint](https://github.com/kint-php/kint) - A debugging and profiling tool.
 * [PHP Console](https://github.com/Seldaek/php-console) - A web debugging console.
 * [PHP Debug Bar](http://phpdebugbar.com/) - A debugging toolbar.


### PR DESCRIPTION
Adding lib to debug PHP applications in terminal, without any IDE. Is equivalent to ipdb in python or byebug in ruby.