### PR TITLE
Adding Gson

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,6 +712,7 @@ Libraries to help manage database schemas and migrations.
 * [Collections](https://github.com/italolelis/collections) - Collections Abstraction library for PHP.
 * [Fractal](https://github.com/thephpleague/fractal) - A library for converting complex data structures to JSON output.
 * [Ginq](https://github.com/akanehara/ginq) - Another PHP library based on .NET's LINQ.
+* [Gson](https://github.com/tebru/gson-php) - A port of Google's Gson library for serializing and deserializing data.
 * [JsonMapper](https://github.com/cweiske/jsonmapper) - A library that maps nested JSON structures onto PHP classes.
 * [Knapsack](https://github.com/DusanKasan/Knapsack) - Collection library inspired by Clojure's sequences.
 * [PHP Collections](https://github.com/schmittjoh/php-collection) - A simple collections library.


### PR DESCRIPTION
This is a library for serializing and deserializing PHP objects. It takes advantage of PHP 7 language features to limit the number of annotations required for type information.

Additionally, it adds support for making (de)serialization decisions based on runtime information and provides a good interface for handling complex custom serializations.

https://github.com/tebru/gson-php