### PR TITLE
Added graphql-php

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,7 @@ Libraries to help manage database schemas and migrations.
 * [API Platform](https://api-platform.com ) - Expose in minutes an hypermedia REST API that embraces JSON-LD, Hydra format.
 * [Apigility](https://github.com/zfcampus/zf-apigility-skeleton) - An API builder built with Zend Framework 2.
 * [Drest](https://github.com/leedavis81/drest) - A library for exposing Doctrine entities as REST resource endpoints.
+* [GraphQL](https://github.com/webonyx/graphql-php) - PHP implementation of GraphQL specification for modern API development.
 * [HAL](https://github.com/blongden/hal) - A Hypertext Application Language (HAL) builder library.
 * [Hateoas](https://github.com/willdurand/Hateoas) - A HATEOAS REST web service library.
 * [Negotiation](https://github.com/willdurand/Negotiation) - A content negotiation library.


### PR DESCRIPTION
[GraphQL](http://graphql.org) is getting traction. There are implementations in almost all popular languages. Proposed library is a PHP implementation, which is already acknowledged by PHP community (1300 stars). 

Conforms to all other contribution guidelines: Minimum requirement is PHP5.5, PSR-compliant via Standard server, has detailed [documentation site](webonyx.github.io/graphql-php/), composer-installable, unit-tested.