### PR TITLE
Add Brick\Math and Brick\Money

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 *Libraries and applications for taking payments and building online e-commerce stores.*
 
 * [Money](https://github.com/moneyphp/money) - A PHP implementation of Fowler's money pattern.
+* [Brick\Money](https://github.com/brick/money) - A money library for PHP with support for custom scales, cash roundings, currency exchange, and more.
 * [OmniPay](https://github.com/thephpleague/omnipay) - A framework agnostic multi-gateway payment processing library.
 * [Payum](https://github.com/payum/payum) - A payment abstraction library.
 * [Shopware](https://github.com/shopware/shopware) - Highly customizable e-commerce software
@@ -660,6 +661,7 @@ Libraries to help manage database schemas and migrations.
 * [ByteUnits](https://github.com/gabrielelana/byte-units) - A library to parse, format and convert byte units in binary and metric systems.
 * [LibPhoneNumber for PHP](https://github.com/giggsey/libphonenumber-for-php) - A PHP implementation of Google's phone number handling library.
 * [Math](https://github.com/moontoast/math) - A library for working with large numbers.
+* [Brick\Math](https://github.com/brick/math) - A library providing large number support: `BigInteger`, `BigDecimal` and `BigRational`.
 * [Numbers PHP](https://github.com/powder96/numbers.php) - A library for working with numbers.
 * [PHP Conversion](https://github.com/Crisu83/php-conversion) - Another library for converting between units of measure.
 * [PHP Units of Measure](https://github.com/triplepoint/php-units-of-measure) - A library for converting between units of measure.


### PR DESCRIPTION
- [Brick\Math](https://github.com/brick/math) offers an implementation of large integer, decimal and rational numbers. It works with GMP, BCMath, and can even work without these extensions thanks to a pure PHP calculator.
- [Brick\Money](https://github.com/brick/money) is based on `Math` and provides exact calculations on monies of any size, with support for roundings, cash roundings, money contexts, currency conversion, and more.