### PR TITLE
Add Brick\Math

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ Libraries to help manage database schemas and migrations.
 ### Numbers
 *Libraries for working with numbers.*
 
+* [Brick\Math](https://github.com/brick/math) - A library providing large number support: `BigInteger`, `BigDecimal` and `BigRational`.
 * [ByteUnits](https://github.com/gabrielelana/byte-units) - A library to parse, format and convert byte units in binary and metric systems.
 * [LibPhoneNumber for PHP](https://github.com/giggsey/libphonenumber-for-php) - A PHP implementation of Google's phone number handling library.
 * [PHP Conversion](https://github.com/Crisu83/php-conversion) - Another library for converting between units of measure.


### PR DESCRIPTION
[Brick\Math](https://github.com/brick/math) offers an implementation of large numbers:

- `BigInteger`
- `BigDecimal`
- `BigRational`

It works with either GMP or BCMath, and can even work without these extensions thanks to a pure PHP calculator. The library automatically uses the fastest calculator implementation available.