### PR TITLE
Moved Porter to architecture section and updated description

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Patchwork](http://patchwork2.org/) - A library for redefining userland functions.
 * [PHP Option](https://github.com/schmittjoh/php-option) - An option type library.
 * [Pipeline](https://github.com/thephpleague/pipeline) - A pipeline pattern implementation.
+* [Porter](https://github.com/ScriptFUSION/Porter) - Data import abstraction library for consuming Web APIs and other data sources.
 * [Ruler](https://github.com/bobthecow/Ruler) - A simple stateless production rules engine.
 * [RulerZ](https://github.com/K-Phoen/rulerz) - A powerful rule engine and implementation of the Specification pattern.
 
@@ -714,7 +715,6 @@ Libraries to help manage database schemas and migrations.
 * [Knapsack](https://github.com/DusanKasan/Knapsack) - Collection library inspired by Clojure's sequences.
 * [PHP Collections](https://github.com/schmittjoh/php-collection) - A simple collections library.
 * [PINQ](https://github.com/TimeToogo/Pinq) - A PHP library based on .NET's LINQ (Language Integrated Query).
-* [Porter](https://github.com/ScriptFUSION/Porter) - Data import abstraction framework.
 * [Serializer](https://github.com/schmittjoh/serializer) - A library for serialising and de-serialising data.
 * [Totem](https://github.com/Wisembly/Totem) - A library to manage and create data changesets.
 * [YaLinqo](https://github.com/Athari/YaLinqo) - Yet Another LINQ to Objects for PHP.


### PR DESCRIPTION
I'd like to propose reorganization of Porter under the architecture section as I feel it is a much better fit there. Its main purpose is to provide structure through its abstraction for data imports. This isn't the same thing as *data structure*, it's an *architectural* structure because we're more concerned with structuring the program and less about the structure of data. This is especially true of the upcoming [v4](https://github.com/ScriptFUSION/Porter/pull/46) which removes or migrates almost all implementations and replaces them with interfaces, but I have a hard time justifying its current classification even now.