### PR TITLE
Add Progpilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [PHP Metrics](https://github.com/phpmetrics/PhpMetrics) - A static metric library.
 * [PHP Migration](https://github.com/monque/PHP-Migration) - A static analyzer for PHP version migration.
 * [PHPStan](https://github.com/phpstan/phpstan) - A PHP Static Analysis Tool.
+* [Progpilot](https://github.com/designsecurity/progpilot) - A static security analysis tool for PHP code.
 * [Pslam](https://github.com/vimeo/psalm) - A static analysis tool for finding errors in PHP applications.
 
 ## Architectural


### PR DESCRIPTION
Progpilot is a static security analysis tool for PHP code
Free and under the MIT License
Fully customizable and very flexible
Latest release in Decembre 2017
Specially developed for finding security vulnerabilities (currently most of these tools are commercials tools or not maintained)