### PR TITLE
Adding new dev env: devilbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,6 +838,7 @@ Libraries to help manage database schemas and migrations.
 * [Puppet](https://puppet.com/) - A server automation framework and application.
 * [Vagrant](https://www.vagrantup.com/) - A portable development environment utility.
 * [Docker](https://www.docker.com/) - A containerization platform.
+* [Devilbox](https://github.com/cytopia/devilbox) - A dockerized and general-purpose LAMP/MEAN stack for every PHP version.
 
 ## Virtual Machines
 *Alternative PHP virtual machines.*


### PR DESCRIPTION
This PR will add another PHP Development Environment: [devilbox](https://github.com/cytopia/devilbox).

> The devilbox is a modern and highly customisable dockerized PHP stack supporting full LAMP and MEAN and running on all major platforms. The main goal is to easily switch and combine any version required for local development. It supports an unlimited number of projects for which vhosts and DNS records are created automatically. Email catch-all and popular development tools will be at your service as well. Configuration is not necessary, as everything is pre-setup with mass virtual hosting.
