### PR TITLE
Added Dwoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 *Libraries and tools for templating and lexing.*
 
 * [Aura.View](https://github.com/auraphp/Aura.View) - Provides TemplateView and TwoStepView using PHP as the tempting language, with support for partials, sections, and helpers.
+* [Dwoo](https://github.com/dwoo-project/dwoo) - Smarty inspired template engine
 * [Foil](https://github.com/FoilPHP/Foil) - Another native PHP templating library.
 * [Lex](https://github.com/pyrocms/lex) - A lightweight template parser.
 * [MtHaml](https://github.com/arnaud-lb/MtHaml) - A PHP implementation of the HAML template language.


### PR DESCRIPTION
Dwoo is another template engine that has Smarty syntax support and has plugin support that can be written with classes (instead like functions in Smarty). Maybe it's not so popular like Smarty, Twig or Blade but I still on Internet is possible to find many lists where this template engine is recommended by someone (f.e. [6 Best Template Engines in PHP [updated]](http://acmeextension.com/best-templating-engine/), Top 5 [PHP Template Engines](https://www.sitecrafting.com/top-5-php-template-engines/), [14+ Best PHP Template Engines to Design your PHP Web Project!](https://www.template.net/web-templates/php-templates/php-template-engine/) ). So, I think it would be a good idea to add it to the list.