### PR TITLE
Adding new lib to debug session

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [APM](http://pecl.php.net/package/APM) - Monitoring extension collecting errors and statistics into SQLite/MySQL/StatsD.
 * [Barbushin PHP Console](https://github.com/barbushin/php-console) - Another web debugging console using Google Chrome.
 * [Blackfire.io](https://blackfire.io) - A low-overhead code profiler.
+* [Dephpugger](https://github.com/tacnoman/dephpugger) - Debug with breakpoints to run in terminal without IDE.
 * [Kint](https://github.com/kint-php/kint) - A debugging and profiling tool.
 * [PHP Console](https://github.com/Seldaek/php-console) - A web debugging console.
 * [PHP Debug Bar](http://phpdebugbar.com/) - A debugging toolbar.


### PR DESCRIPTION
Adding the lib Dephpugger to debug session. Dephpugger is a lib to add breakpoints in code and stop execution in terminal runner (without IDE).