### PR TITLE
Update with Brew PHP Switcher. Remove deprecated PHP tap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,8 +759,8 @@ Libraries to help manage database schemas and migrations.
 ### PHP Installation
 *Tools to help install and manage PHP on your computer.*
 
-* [HomeBrew PHP](https://github.com/Homebrew/homebrew-php) - A PHP tap for HomeBrew.
 * [HomeBrew](https://brew.sh/) - A package manager for OSX.
+* [Brew PHP Switcher](https://github.com/philcook/brew-php-switcher) - Brew PHP switcher.
 * [PHP Brew](https://github.com/phpbrew/phpbrew) - A PHP version manager and installer.
 * [PHP Build](https://github.com/php-build/php-build) - Another PHP version installer.
 * [PHP OSX](https://php-osx.liip.ch/) - A PHP installer for OSX.


### PR DESCRIPTION
Brew PHP Switcher is the most currently maintained tool for switching between versions of php.