### PR TITLE
Added PeachPie to list of VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,7 +782,7 @@ Libraries to help manage database schemas and migrations.
 
 * [Hack](https://hacklang.org/) - A programming language for HHVM that interoperates seamlessly with PHP.
 * [HHVM](https://github.com/facebook/hhvm) - A Virtual Machine, Runtime and JIT for PHP by Facebook.
-* [PeachPie](https://github.com/peachpiecompiler/peachpie) - PeachPie is a PHP compiler and runtime for .NET and .NET Core, which allows entire PHP applications to run on the modern, secure and performant .NET and .NET Core platforms.
+* [PeachPie](https://github.com/peachpiecompiler/peachpie) - PHP compiler and runtime for .NET and .NET Core.
 
 ### Text Editors and IDEs
 *Text Editors and Integrated Development Environments (IDE) with support for PHP.*

--- a/README.md
+++ b/README.md
@@ -782,6 +782,7 @@ Libraries to help manage database schemas and migrations.
 
 * [Hack](https://hacklang.org/) - A programming language for HHVM that interoperates seamlessly with PHP.
 * [HHVM](https://github.com/facebook/hhvm) - A Virtual Machine, Runtime and JIT for PHP by Facebook.
+* [PeachPie](https://github.com/peachpiecompiler/peachpie) - PeachPie is a PHP compiler and runtime for .NET and .NET Core, which allows entire PHP applications to run on the modern, secure and performant .NET and .NET Core platforms.
 
 ### Text Editors and IDEs
 *Text Editors and Integrated Development Environments (IDE) with support for PHP.*


### PR DESCRIPTION
Added [PeachPie compiler](https://github.com/peachpiecompiler/peachpie) to the list of alternative VMs. I felt that it was the most appropriate place to put it, although it is not really a VM, but rather a complete runtime replacement.