### PR TITLE
Update a link to daux.io repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 *Libraries for generating project documentation.*
 
 * [APIGen](https://github.com/apigen/apigen) - Another API documentation generator.
-* [daux.io](https://github.com/justinwalsh/daux.io) - A documentation generator which uses Markdown files.
+* [daux.io](https://github.com/dauxio/daux.io) - A documentation generator which uses Markdown files.
 * [PHP Documentor 2](https://github.com/phpDocumentor/phpDocumentor2) - A documentation generator.
 * [phpDox](http://phpdox.de/) - A documentation generator for PHP projects (that is not limited to API documentation).
 * [Sami](https://github.com/FriendsOfPHP/Sami) - An API documentation generator.


### PR DESCRIPTION
Main daux.io repository has been moved to a dedicated [organization](https://github.com/dauxio) [repository](https://github.com/dauxio/daux.io)