### PR TITLE
Add PHP-code generator (based on OAS) for Laravel framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ Libraries to help manage database schemas and migrations.
 ### API
 *Libraries and web tools for developing APIs.*
 
+* [API Generator](https://github.com/SoliDry/api-generator) - PHP-code generator (based on OAS) for Laravel framework, with complete support of JSON-API data format
 * [API Platform](https://api-platform.com ) - Expose in minutes an hypermedia REST API that embraces JSON-LD, Hydra format.
 * [Laminas API Tool Skeleton](https://github.com/laminas-api-tools/api-tools-skeleton) - An API builder built with the Laminas Framework.
 * [Drest](https://github.com/leedavis81/drest) - A library for exposing Doctrine entities as REST resource endpoints.


### PR DESCRIPTION
Why this repo/lib should be added?
- it is unique in its approach or function
- it fills a niche gap in the market

Qualities, code-coverage and other props:

[![Build Status](https://scrutinizer-ci.com/g/SoliDry/api-generator/badges/build.png?b=master)](https://scrutinizer-ci.com/g/SoliDry/api-generator/build-status/master)
[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/SoliDry/api-generator/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/SoliDry/api-generator/?branch=master)
[![Total Downloads](https://poser.pugx.org/solidry/api-generator/downloads)](https://packagist.org/packages/solidry/api-generator)
[![Latest Stable Version](https://poser.pugx.org/solidry/api-generator/v/stable)](https://packagist.org/packages/solidry/api-generator)
[![Code Intelligence Status](https://scrutinizer-ci.com/g/SoliDry/api-generator/badges/code-intelligence.svg?b=master)](https://scrutinizer-ci.com/code-intelligence)
[![codecov](https://codecov.io/gh/SoliDry/api-generator/branch/master/graph/badge.svg)](https://codecov.io/gh/SoliDry/api-generator)
[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)

As you can see project is highly maintained and is relatively fresh/new.

There are a few competitors in code-gen area for php, but they more about just a Laravel or Laravel+json-api, there is no OpenApi support (in one of them only Swagger supported) and not all features of json-api provided (e.g.: support for extended format, errors etc).

But the main idea is that it generates many things automatically:
- Controllers
- FormRequests
- Models
- MiddleWares
- Migrations
- Routes
- Tests

and even regenerates it-self with history look-back, roll-back, merge etc

Thank u