### PR TITLE
Remove Propel ORM

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,6 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Eloquent](https://github.com/illuminate/database) - A simple ORM (L5).
 * [LazyRecord](https://github.com/corneltek/LazyRecord) - A fast ORM designed for simplicity, extendability and performance.
 * [Pomm](https://github.com/chanmix51/Pomm) - An Object Model Manager for PostgreSQL.
-* [Propel](http://propelorm.org/) - A fast ORM, migration library and query builder.
 * [ProxyManager](https://github.com/Ocramius/ProxyManager) - A set of utilities to generate proxy objects for data mappers.
 * [RedBean](https://redbeanphp.com/index.php) - A lightweight, configuration-less ORM.
 * [Spot2](https://github.com/spotorm/spot2) - A MySQL datamapper ORM.


### PR DESCRIPTION
https://github.com/propelorm/Propel2#status-of-the-project

> Our advice:
>
> Use Doctrine if you are looking for a long-term supported, full-featured (and difficult to learn) and stable ORM.
> Use easy to learn Eloquent for prototyping and smaller projects.
> Help us build Propel3, which aims someday to be both of the above.