### PR TITLE
Fix CI failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --white-list igor.io,symfony,toranproxy.com,vagrantup.com,3v4l.org,voicesoftheelephpant.com
+  - awesome_bot README.md --white-list igor.io,symfony,toranproxy.com,vagrantup.com,3v4l.org,voicesoftheelephpant.com,drupal.org
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -891,7 +891,7 @@ Various resources, such as books, websites and articles, for improving your PHP 
 * [Nomad PHP Lightning Talks](https://www.youtube.com/c/nomadphp) - 10 to 15 minute Lightning Talks by PHP community members.
 * [PHP UK Conference](https://www.youtube.com/user/phpukconference/videos) - A collection of videos from the PHP UK Conference.
 * [Programming with Anthony](https://www.youtube.com/playlist?list=PLM-218uGSX3DQ3KsB5NJnuOqPqc5CW2kW) - A video series by Anthony Ferrara.
-* [Taking PHP Seriously](https://www.infoq.com/presentations/php-history) - A talk outlining PHP's strengths by Keith Adams of Facebook.
+* [Taking PHP Seriously](https://www.infoq.com/presentations/php-history/) - A talk outlining PHP's strengths by Keith Adams of Facebook.
 
 ### PHP Podcasts
 *Podcasts with a focus on PHP topics.*


### PR DESCRIPTION
`drupal.org` seems to be denying bot access. 👀 

The server returns 403 against "User-Agent: awesome_bot":

```sh
$ curl -D - -s -o /dev/null https://www.drupal.org -H "User-Agent: awesome_bot" | grep HTTP
HTTP/2 403
```

([`awesome_bot` is a user-agent text used in awesome_bot.](https://github.com/dkhamsing/awesome_bot/blob/a1911a8ee4575a6bd603117d983a2a12be8df209/lib/awesome_bot/net.rb#L13))

We can receive 200 if change the User-Agent to other client one (e.g. curl ):

```sh
$ curl -D - -s -o /dev/null https://www.drupal.org -H "User-Agent: curl/7.54.0" | grep HTTP
HTTP/2 200
```