### PR TITLE
Add Square PHP SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,7 @@ Libraries to help manage database schemas and migrations.
 * [Dropbox SDK](https://github.com/dropbox/dropbox-sdk-php) - The official PHP Dropbox SDK library.
 * [Github](https://github.com/KnpLabs/php-github-api) - A library to interface with the Github API.
 * [Mailgun](https://github.com/mailgun/mailgun-php) The official Mailgun PHP API.
+* [Square](https://github.com/square/connect-php-sdk) - The official Square PHP SDK for payments and other Square APIs.
 * [Stripe](https://github.com/stripe/stripe-php) - The official Stripe PHP library.
 * [Twilio](https://github.com/twilio/twilio-php) - The official Twilio PHP REST API.
 


### PR DESCRIPTION
The [Square PHP SDK](https://github.com/square/connect-php-sdk) provides access to [payments and other Square APIs](https://squareup.com/us/en/developers).