### PR TITLE
Added WP Kickstart to Build Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Box](https://github.com/humbug/box) - A utility to build PHAR files.
 * [Construct](https://github.com/jonathantorres/construct) - A PHP project/micro-package generator.
 * [Phing](https://www.phing.info/) - A PHP project build system inspired by Apache Ant.
+* [WP Kickstart](https://produkte.webtimal.ch/wp-kickstart/) - A lightweight tool for automating WordPress installations.
 
 ### Task Runners
 *Libraries for automating and running tasks.*


### PR DESCRIPTION
https://produkte.webtimal.ch/wp-kickstart

The script is easy to use, properly documented and actively maintained. As there is no comparable tool, it fills a niche for web developers working regularly with WordPress.