### PR TITLE
Add jPHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,6 +808,7 @@ Libraries to help manage database schemas and migrations.
 
 * [Hack](https://hacklang.org/) - A programming language for HHVM.
 * [HHVM](https://github.com/facebook/hhvm) - A Virtual Machine, Runtime and JIT for PHP by Facebook.
+* [jPHP](https://github.com/jphp-group/jphp/) - A new implementation for PHP which uses the Java VM.
 
 ### Text Editors and IDEs
 *Text Editors and Integrated Development Environments (IDE) with support for PHP.*


### PR DESCRIPTION
### Goals

JPHP is not a replacement for the Zend PHP engine or Facebook HHVM. We don’t plan to implement the zend runtime libraries (e.g. Curl, PRCE, etc.) for JPHP.

Our project started in October 2013. There were a few reasons for that:

1. Ability to use java libraries in PHP
2. Upgrading performance via JIT and JVM
3. Replacing the ugly runtime library of Zend PHP with a better runtime library.
4. Using the PHP language not only on the web
5. Also: unicode for strings and threads

### Features

+ PHP 5.6+ (and many language features from PHP 7.0 and 7.1).
+ JIT (~2.5x faster PHP 5.6, ~1.1x faster PHP 7.0, ~1.5x slower PHP 7.1).
+ Using java libraries and classes in PHP code.
+ Unicode for strings (UTF-16, like in Java)
+ [Threading](https://github.com/jphp-group/jphp/tree/master/jphp-runtime/api-docs/classes/php/lang/Thread.md), [Sockets](https://github.com/jphp-group/jphp/tree/master/jphp-runtime/api-docs/classes/php/net/Socket.md), [Environment](https://github.com/jphp-group/jphp/tree/master/jphp-runtime/api-docs/classes/php/lang/Environment.md) architecture (like sandbox objects in the runkit zend extension).
+ GUI ([JavaFX](https://github.com/jphp-group/jphp-gui-ext) or [SWT](https://github.com/jphp-group/jphp-swt-ext))
+ Embedded cache system for classes and functions
+ Optional Hot Reloading for classes and functions
+ Ability to use on **Android** OS : [jphp-android](https://github.com/jphp-group/jphp-android)
