### PR TITLE
Add "Scraping" to ToC link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
     - [Templating](#templating)
     - [Static Site Generators](#static-site-generators)
     - [HTTP](#http)
+    - [Scraping](#scraping)
     - [Middlewares](#middlewares)
     - [URL](#url)
     - [Email](#email)


### PR DESCRIPTION
Link to the list of Scraping libraries is missing from Table of Contents. This PR aims to fix it.