### PR TITLE
Add guzzle psr-18 adapter in http section

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 
 * [Buzz](https://github.com/kriswallsmith/Buzz) - Another HTTP client.
 * [Guzzle]( https://github.com/guzzle/guzzle) - A comprehensive HTTP client.
+* [Guzzle PSR-18 Adapter](https://github.com/ricardofiorani/guzzle-psr18-adapter) - A simple guzzle PSR-18 adapter
 * [HTTPlug](http://httplug.io) - An HTTP client abstraction without binding to a specific implementation.
 * [PHP VCR](https://php-vcr.github.io/) - A library for recording and replaying HTTP requests.
 * [Requests](https://github.com/rmccue/Requests) - A simple HTTP library.


### PR DESCRIPTION
As Guzzle is not compatible with PSR-18 this package is quite useful and works out of the box.