### PR TITLE
add phpstatic github link for PHP Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Libraries to help manage database schemas and migrations.
 * [Puppet](https://puppet.com/) - A server automation framework and application.
 * [Vagrant](https://www.vagrantup.com/) - A portable development environment utility.
 * [Docker](https://www.docker.com/) - A containerization platform.
+* [PHP Static](https://phpstatic.com/) A tools to provide PHP packages without dependency hell.
 
 ### Virtual Machines
 *Alternative PHP virtual machines.*


### PR DESCRIPTION
Hi, I am made this pull request to try again add phpstatic Installation source.

phpstatic provide variety of ways (docker, alpine package, debian package,  redhat package,  macOS ) to install the  latest PHP version with multiple extension support.

This is a new projects and more document will add into github late. 