### PR TITLE
Add composer-require-checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Satis](https://github.com/composer/satis) - A static Composer repository generator.
 * [tooly](https://github.com/tommy-muehle/tooly-composer-script) - A library to manage PHAR files in project using Composer.
 * [Toran Proxy](https://toranproxy.com) - A static Composer repository and proxy.
+* [Compoer Require Checker](https://github.com/maglnet/ComposerRequireChecker) - CLI tool to analyze composer dependencies and verify that no unknown symbols are used in the sources of a package
 
 ### Frameworks
 *Web development frameworks.*


### PR DESCRIPTION
Add Composer Require Checker into `Dependency Management Extras`-Section.
A good scanner which analyzes your code if there are symbols used, which are not required in your root `composer.json`.

URL: https://github.com/maglnet/ComposerRequireChecker