### PR TITLE
Add Optic

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [daux.io](https://github.com/dauxio/daux.io) - A documentation generator which uses Markdown files.
 * [PHP Documentor 2](https://github.com/phpDocumentor/phpDocumentor) - A documentation generator.
 * [phpDox](http://phpdox.de/) - A documentation generator for PHP projects (that is not limited to API documentation).
+* [Optic](https://github.com/opticdev/optic) - Optic automatically documents and tests your APIs
 
 ### Security
 *Libraries for generating secure random numbers, encrypting data and scanning and testing for vulnerabilities.*


### PR DESCRIPTION
Optic automatically documents and tests your APIs.

I think Optic is awesome because its super simple to use and lets you easily add docs to any project. For most api projects, maintaining and creating documentation is a pain, and optic greatly streamlines this process.

This project integrates seamlessly with PHP projects like Laravel to build documentation for your project

Repo: opticdev/optic, Homepage: useoptic.com