### PR TITLE
Add MailHog - Testing email sending with PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [HTTP Mock](https://github.com/InterNations/http-mock) - A library for mocking HTTP requests in unit tests.
 * [Infection](https://github.com/infection/infection) - An AST-based PHP Mutation testing framework.
 * [Kahlan](https://github.com/kahlan/kahlan) - Full stack Unit/BDD testing framework with built-in stub, mock and code-coverage support.
+* [MailHog](https://github.com/les-enovateurs/mailhog-examples), PHP testing email with MailHog. Can be use with Docker and GitHub Actions.
 * [Mink](http://mink.behat.org/en/latest/) - Web acceptance testing.
 * [Mockery](https://github.com/mockery/mockery) - A mock object library for testing.
 * [ParaTest](https://github.com/paratestphp/paratest) - A parallel testing library for PHPUnit.

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [HTTP Mock](https://github.com/InterNations/http-mock) - A library for mocking HTTP requests in unit tests.
 * [Infection](https://github.com/infection/infection) - An AST-based PHP Mutation testing framework.
 * [Kahlan](https://github.com/kahlan/kahlan) - Full stack Unit/BDD testing framework with built-in stub, mock and code-coverage support.
-* [MailHog](https://github.com/les-enovateurs/mailhog-examples), PHP testing email with MailHog. Can be use with Docker and GitHub Actions.
+* [MailHog](https://github.com/les-enovateurs/mailhog-examples) - PHP testing email with MailHog. Can be used with Docker and GitHub Actions.
 * [Mink](http://mink.behat.org/en/latest/) - Web acceptance testing.
 * [Mockery](https://github.com/mockery/mockery) - A mock object library for testing.
 * [ParaTest](https://github.com/paratestphp/paratest) - A parallel testing library for PHPUnit.


### PR DESCRIPTION
Hi!
MailHog is a tool that can be installed with Docker or GitHub Action to test email sending. 
The repository that I suggest shows how to use send Mail with PHP and to configure it, in order to work with MailHog easily.
MailHog is a Go-based fake SMTP, that also contains a precious API to check if the mail has been received.
Thanks for your review.