### PR TITLE
Add OctoLinker

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,7 @@ Libraries to help manage database schemas and migrations.
 * [Metrics](https://github.com/beberlei/metrics) - A simple metrics API library.
 * [noCAPTCHA](https://github.com/ARCANEDEV/noCAPTCHA) - Helper for Google's noCAPTCHA (reCAPTCHA).
 * [Nmap](https://github.com/willdurand/nmap) - A PHP wrapper around [Nmap](https://nmap.org/).
+* [OctoLinker](https://octolinker.now.sh) - A code navigation browser extension for GitHub
 * [Pagerfanta](https://github.com/whiteoctober/Pagerfanta) - A pagination library.
 * [PHP PassBook](https://github.com/eymengunay/php-passbook) - A PHP library for iOS PassBook.
 * [PHP-ML](https://github.com/php-ai/php-ml) - A library for Machine Learning in PHP.


### PR DESCRIPTION
[OctoLinker](https://octolinker.now.sh) is a browser extension for GitHub, that turns code into links. I created OctoLinker many years ago and it's used by over 25,000 developers, primarily JS developers. 

As of today we added support for core classes and functions that will link to their respective php.net page.

![Oct-05-2020 21-45-17](https://user-images.githubusercontent.com/1393946/95388902-5325e680-08f3-11eb-9a1c-fdb12804249a.gif)

```php
use ArrayAccess; // => https://www.php.net/manual/en/class.arrayaccess.php
use function preg_last_error; // => https://www.php.net/manual/en/function.preg-last-error.php
```

OctoLinker also turn dependencies defined in a `composer.json` file into links

![image](https://user-images.githubusercontent.com/1393946/95389132-ab5ce880-08f3-11eb-98c3-c129a8809a78.png)

There is also a [live demo](https://octolinker-demo.now.sh/illuminate/auth/blob/master/composer.json#L18)


