### PR TITLE
Add info about Manticore Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,8 @@ Libraries to help manage database schemas and migrations.
 * [ElasticSearch PHP](https://github.com/elastic/elasticsearch-php) - The official client library for [ElasticSearch](https://www.elastic.co/).
 * [Solarium](https://www.solarium-project.org/) - A client library for [Solr](https://lucene.apache.org/solr/).
 * [Sphinx Search](https://github.com/ripaclub/sphinxsearch) - Sphinx Search library provides SphinxQL indexing and searching features
-* [SphinxQL query builder](https://foolcode.github.io/SphinxQL-Query-Builder/) - A query library for the [Sphinx](https://sphinxsearch.com/) search engine.
+* [Manticore Search](https://github.com/manticoresoftware/manticoresearch) - truly open source and active fork of Sphinx Search
+* [SphinxQL query builder](https://foolcode.github.io/SphinxQL-Query-Builder/) - A query library for the [Sphinx](https://sphinxsearch.com/) and [Manticore](https://manticoresearch.com/) search engines.
 
 ### Command Line
 *Libraries related to the command line.*


### PR DESCRIPTION
Sphinx as an open source project has been forked to Manticore Search and has been being actively developed since 2017