### PR TITLE
Providing Email Delivery Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Mautic](https://github.com/mautic/mautic) - Email marketing automation
 * [PHPMailer](https://github.com/PHPMailer/PHPMailer) - Another mailer solution.
 * [PHP IMAP](https://github.com/barbushin/php-imap) - A library to access mailboxes via POP3, IMAP and NNTP.
-* [Stampie](https://github.com/Stampie/Stampie) - A library for email services such as [SendGrid](https://sendgrid.com/), [PostMark](https://postmarkapp.com), [MailGun](https://www.mailgun.com/) and [Mandrill](https://mailchimp.com/features/transactional-email/).
+* [Stampie](https://github.com/Stampie/Stampie) - A library for email services such as [SendGrid](https://sendgrid.com/), [PostMark](https://postmarkapp.com), [MailGun](https://www.mailgun.com/) and [Mandrill](https://mailchimp.com/features/transactional-email/) [Mailcot](https://mailcot.com/services/email-marketing-service/), [Migomail](https://migomail.com/smtp-service) .
 * [SwiftMailer](https://swiftmailer.symfony.com) - A mailer solution.
 * [Symfony Mailer](https://github.com/symfony/mailer) - A powerful library for creating and sending emails.
 


### PR DESCRIPTION
SMTP Configuration settings for [Migomail](https://migomail.com/) - TLS : 

Outgoing Server Name: sn1.migomta.one
Port: 587
Security Type: TLS

Require Authentication: Yes. 

Email address should match the email address/ aliases of the account, for which the authentication details are provided.