### PR TITLE
Add m2cgen for transpiling ML models into PHP code

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,6 +801,7 @@ Libraries to help manage database schemas and migrations.
 * [JSON Lint](https://github.com/Seldaek/jsonlint) - A JSON lint utility.
 * [JSONPCallbackValidator](https://github.com/willdurand/JsonpCallbackValidator) - A library for validating JSONP callbacks.
 * [Lock](https://github.com/php-lock/lock) - A lock library to provide exclusive execution.
+* [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native PHP code with zero dependencies.
 * [Metrics](https://github.com/beberlei/metrics) - A simple metrics API library.
 * [noCAPTCHA](https://github.com/ARCANEDEV/noCAPTCHA) - Helper for Google's noCAPTCHA (reCAPTCHA).
 * [Nmap](https://github.com/willdurand/nmap) - A PHP wrapper around [Nmap](https://nmap.org/).


### PR DESCRIPTION
Hey there! Thanks a lot for this list!

I'm not sure whether this contribution fits the project ideology 100% or not. `m2cgen` is **not written** in PHP but **generates** PHP code. It is a lightweight library with command line interface which allows to transpile trained machine learning models into a native code of PHP programming language. Examples of generated PHP code can be found [here](https://github.com/BayesWitnesses/m2cgen/tree/master/generated_code_examples/php). Given the lack of any ML-related libraries in PHP (there is no separate `ML` section which is quite typical for such lists in other languages and only `PHP-ML` is present in misc section), I believe it's worth mentioning `m2cgen` project here. Please feel free to close this PR if you have an opposite opinion. Thanks a lot for your time and consideration!

https://github.com/BayesWitnesses/m2cgen