### PR TITLE
Reference QOI Codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Imagine](https://imagine.readthedocs.io/en/latest/index.html) - An image manipulation library.
 * [Intervention Image](https://github.com/Intervention/image) - Another image manipulation library.
 * [PHP Image Workshop](https://github.com/Sybio/ImageWorkshop) - Another image manipulation library.
+* [QOI Image encoder](https://github.com/MKCG/php-qoi) - A QOI codec
 
 ### Testing
 *Libraries for testing codebases and generating test data.*


### PR DESCRIPTION
I made a QOI Codec in PHP.

This codec use a FFI when the library detects that the CPU is based on the x86_64 architecture, otherwise it fallbacks on a plain PHP implementation.

Source :
- [Detection of the CPU architecture](https://github.com/MKCG/php-qoi/blob/main/src/Codec.php#L47)
- [Usage of the FFI extension](https://github.com/MKCG/php-qoi/blob/main/src/FFI/x86.php#L35)
- [Definition of the C library](https://github.com/MKCG/php-qoi/tree/main/src/FFI/lib)
- [Shared objects](https://github.com/MKCG/php-qoi/tree/main/src/FFI/bin)