### PR TITLE
Add `kubephp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,7 @@ Libraries to help manage database schemas and migrations.
 *Infrastructure for providing PHP applications and services.*
 
 * [appserver.io](https://github.com/appserver-io/appserver) - A multithreaded application server for PHP, written in PHP.
+* [kubephp](https://github.com/sherifabdlnaby/kubephp) - Production Grade, Rootless, and Optimized PHP Container Image Template for Cloud-Native Deployments.
 * [php-pm](https://github.com/php-pm/php-pm) - A process manager, supercharger and load balancer for PHP applications.
 * [RoadRunner](https://github.com/spiral/roadrunner) - High-performance PHP application server, load-balancer and process manager.
 


### PR DESCRIPTION
Suggesting to add https://github.com/sherifabdlnaby/kubephp to Awesome PHP.

I understand that "self-promotion" is frowned upon, however, I found no similar project referenced here.

I put it under `Infrastructure` because it's as close to what `kubephp` is, which is being a Production base template for your docker image.

The second category that it might belong to is `Development Environment`, although `kubephp` helps with Development with the `dev` docker image, it's also a production docker image template and hence I didn't put it under 'Development Environment`.