### PR TITLE
Fix `#files` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
     - [Middlewares](#middlewares)
     - [URL](#url)
     - [Email](#email)
-    - [Files](#files)
+    - [Files](#Files)
     - [Streams](#streams)
     - [Dependency Injection](#dependency-injection)
     - [Imagery](#imagery)


### PR DESCRIPTION
Github taking to repo files instead of the reference down there.

### Reproduce by clicking this link
https://github.com/ziadoz/awesome-php/#files

![image](https://user-images.githubusercontent.com/9916806/153781240-f0332e67-563f-422e-bd9e-f5342fb5e579.png)
