### PR TITLE
Remove bobthecow/Ruler - no longer maintained / PHP5 only

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,6 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Patchwork](http://patchwork2.org/) - A library for redefining userland functions.
 * [Pipeline](https://github.com/thephpleague/pipeline) - A pipeline pattern implementation.
 * [Porter](https://github.com/ScriptFUSION/Porter) - Data import abstraction library for consuming Web APIs and other data sources.
-* [Ruler](https://github.com/bobthecow/Ruler) - A simple stateless production rules engine.
 * [RulerZ](https://github.com/K-Phoen/rulerz) - A powerful rule engine and implementation of the Specification pattern.
 
 ### Debugging and Profiling


### PR DESCRIPTION
Unfortunately this library does not appear to be actively maintained anymore. The contributor _has_ responded to one comment or another here and there, but it's been very infrequent. There are issues and PRs stacking up, and contributors in the comments wondering if the library has been abandoned.

Additionally, 1) the library is supposedly built for PHP5 and not PHP7, and 2) the library is not findable on Packagist, making it unnecessarily difficult to install it using Composer without a fork.

Therefore I sadly but respectfully submit this library for removal from the Awesome list.