### PR TITLE
Add PHP Version Audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,8 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [PHP Encryption](https://github.com/defuse/php-encryption) - Secure PHP Encryption Library.
 * [PHP SSH](https://github.com/Herzult/php-ssh) - An experimental object orientated SSH wrapper library.
 * [PHPSecLib](http://phpseclib.sourceforge.net/) - A pure PHP secure communications library.
-* [random_compat](https://github.com/paragonie/random_compat) - PHP 5.x support for `random_bytes()` and `random_int()`
+* [PHP Version Audit](https://www.github.developerdan.com/php-version-audit/) - A tool to programmatically check a PHP version for known CVEs and support end dates. Great for CI/CD builds.
+* [random_compat](https://github.com/paragonie/random_compat) - PHP 5.x support for `random_bytes()` and `random_int()`.
 * [RandomLib](https://github.com/ircmaxell/RandomLib) - A library for generating random numbers and strings.
 * [Symfony Security Monitoring](https://security.symfony.com/) - A web tool to check your Composer dependencies for security advisories, previously known as "SensioLabs Security Check".
 * [SQLMap](https://github.com/sqlmapproject/sqlmap) - An automatic SQL injection and database takeover tool. 


### PR DESCRIPTION
## Intro 
PHP Version Audit: A tool to programmatically check a PHP version for known CVEs and support dates. Great for CI/CD builds.

* [Project page](https://www.github.developerdan.com/php-version-audit/)
* [Repo](https://github.com/lightswitch05/php-version-audit)

## Why should it be included?

I've been running this repo for over three years. One of the coolest things about it (IMO), is that it self-updates, sourcing directly from the PHP changelog twice a day. Over the past three years, I put together some stats and found that PHP Version Audit has discovered CVE announcements on median of 5 hours after the Changelog update. The [NVE CVE database](https://nvd.nist.gov/) gets updated with the CVEs on median of 260 hours - or almost 11 days after the Changelog update. That makes PHP Version Audit 98% faster at notifying of new CVEs than other tools that source from the CVE Database. I think that is pretty cool! 

Beyond all that, its designed to be used programmatically. Set it up in your CI/CD to get notified when its time to bump that PHP version in your Dockerfile.

## Usage

Using the docker image, you could check a vulnerable docker version (`8.1.11`):

```shell
$ docker run --rm -t lightswitch05/php-version-audit:latest --fail-security --version=8.1.11
{
    "auditVersion": "8.1.11",
    "hasVulnerabilities": true,
    "hasSecuritySupport": true,
    "hasActiveSupport": true,
    "isLatestPatchVersion": false,
    "isLatestMinorVersion": false,
    "isLatestVersion": false,
    "latestPatchVersion": "8.1.15",
    "latestMinorVersion": "8.2.2",
    "latestVersion": "8.2.2",
    "activeSupportEndDate": "2023-11-25T00:00:00+0000",
    "securitySupportEndDate": "2024-11-25T00:00:00+0000",
    "rulesLastUpdatedDate": "2023-02-13T02:56:21+0000",
    "vulnerabilities": {
        "CVE-2022-31630": {
            "id": "CVE-2022-31630",
            "baseScore": 7.1,
            "publishedDate": "2022-11-14T07:15:00+0000",
            "lastModifiedDate": "2022-12-23T17:05:00+0000",
            "description": "In PHP versions prior to 7.4.33, 8.0.25 and 8.2.12, when using imageloadfont() function in gd extension, it is possible to supply a specially crafted font file, such as if the loaded font is used with imagechar() function, the read outside allocated buffer will be used. This can lead to crashes or disclosure of confidential information."
        },
        "CVE-2022-37454": {
            "id": "CVE-2022-37454",
            "baseScore": 9.8,
            "publishedDate": "2022-10-21T06:15:00+0000",
            "lastModifiedDate": "2022-12-08T15:41:00+0000",
            "description": "The Keccak XKCP SHA-3 reference implementation before fdc6fef has an integer overflow and resultant buffer overflow that allows attackers to execute arbitrary code or eliminate expected cryptographic properties. This occurs in the sponge function interface."
        },
        "CVE-2022-31631": null
    }
}
```

Or, you could pipe in the Host's PHP version directly:

```shell
$ docker run --rm -t lightswitch05/php-version-audit:latest --fail-security --version=$(php -r 'echo phpversion();')
{
    "auditVersion": "8.2.2",
    "hasVulnerabilities": false,
    "hasSecuritySupport": true,
    "hasActiveSupport": true,
    "isLatestPatchVersion": true,
    "isLatestMinorVersion": true,
    "isLatestVersion": true,
    "latestPatchVersion": "8.2.2",
    "latestMinorVersion": "8.2.2",
    "latestVersion": "8.2.2",
    "activeSupportEndDate": "2024-12-08T00:00:00+0000",
    "securitySupportEndDate": "2025-12-08T00:00:00+0000",
    "rulesLastUpdatedDate": "2023-02-13T02:56:21+0000",
    "vulnerabilities": {}
}
```