### PR TITLE
Add php-play.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,7 @@ Libraries to help manage database schemas and migrations.
 * [Lychee](https://github.com/electerious/Lychee) - An easy to use and great looking photo-management-system.
 * [MailCatcher](https://github.com/sj26/mailcatcher) - A web tool for capturing and viewing emails.
 * [phpMyAdmin](https://github.com/phpmyadmin/phpmyadmin) - A web interface for MySQL/MariaDB.
+* [PHP Playground](https://php-play.dev) - A real-time playground for testing and learning PHP quickly in the browser.
 * [PHP Queue](https://github.com/CoderKungfu/php-queue) - An application for managing queueing backends.
 * [phpRedisAdmin](https://github.com/ErikDubbelboer/phpRedisAdmin) - A simple web interface to manage [Redis](https://redis.io/) databases.
 * [PHPSandbox](https://phpsandbox.io) - An online IDE for PHP in the browser.


### PR DESCRIPTION
This PR adds [PHP Playground](https://php-play.dev) is a real-time online playground for testing and learning PHP code quickly without setup or installation, to the Web Applications section of the awesome-php list.

I believe [PHP Playground](https://php-play.dev) would be a valuable addition to the list as it provides a user-friendly platform for PHP developers to experiment with and learn PHP in a real-time environment without the need for any setup or installation.