### PR TITLE
Remove `Nomad PHP` YouTube channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,7 +924,6 @@ Various resources, such as books, websites and articles, for improving your PHP 
 ### PHP Videos
 *Fantastic PHP-related videos.*
 
-* [Nomad PHP Lightning Talks](https://www.youtube.com/c/nomadphp) - 10 to 15 minute Lightning Talks by PHP community members.
 * [PHP UK Conference](https://www.youtube.com/user/phpukconference/videos) - A collection of videos from the PHP UK Conference.
 * [Programming with Anthony](https://www.youtube.com/playlist?list=PLM-218uGSX3DQ3KsB5NJnuOqPqc5CW2kW) - A video series by Anthony Ferrara.
 * [Taking PHP Seriously](https://www.infoq.com/presentations/php-history/) - A talk outlining PHP's strengths by Keith Adams of Facebook.


### PR DESCRIPTION
Remove `Nomad PHP` YouTube channel as it is not updated and `nomadphp.com` website is also in the Web Sites section.