### PR TITLE
Remove Lumen micro framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 *Micro frameworks and routers.*
 
 * [Laravel-Zero](https://laravel-zero.com) - A micro-framework for console applications.
-* [Lumen](https://lumen.laravel.com/) - A micro-framework by Laravel.
 * [Mezzio](https://getexpressive.org/) - A micro-framework by Laminas.
 * [Radar](https://github.com/radarphp/Radar.Adr) - An Action-Domain-Responder implementation for PHP.
 * [Silly](https://github.com/mnapoli/silly) - A micro-framework for CLI applications.


### PR DESCRIPTION
Official documentation says: "we no longer recommend that you begin new projects with Lumen". https://lumen.laravel.com/docs/10.x#installation