### PR TITLE
Add PHP AST Viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Code Climate](https://codeclimate.com) - An automated code review.
 * [Editorconfig-Checker](https://github.com/editorconfig-checker/editorconfig-checker.php) - A command line utility which verifies that your files implement your `.editorconfig` rules.
 * [GrumPHP](https://github.com/phpro/grumphp) - A PHP code-quality tool.
+* [PHP AST Viewer](https://php-ast-viewer.com/) - A tool for viewing the Abstract Syntax Tree of PHP code.
 * [PHP Magic Number Detector](https://github.com/povils/phpmnd) - A library that detects magic numbers in code.
 * [PHP Parser](https://github.com/nikic/PHP-Parser) - A PHP parser written in PHP.
 * [PHP Semantic Versioning Checker](https://github.com/tomzx/php-semver-checker) - A command line utility that compares two source sets and determines the appropriate semantic versioning to apply.


### PR DESCRIPTION
The PHP AST Viewer is a tool for viewing the Abstract Syntax Tree of PHP code. By visualizing the structure, it helps developers gain a deeper understanding of the code, thus improving code quality and maintenance efficiency.


## Demo video

https://github.com/RightCapitalHQ/php-ast-viewer/assets/43896664/e6dd70c3-5e58-466d-808e-6eaac383d37f