### PR TITLE
Update phpDocumentor info

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 
 * [APIGen](https://github.com/apigen/apigen) - Another API documentation generator.
 * [daux.io](https://github.com/dauxio/daux.io) - A documentation generator that uses Markdown files.
-* [PHP Documentor 2](https://github.com/phpDocumentor/phpDocumentor) - A documentation generator.
+* [phpDocumentor](https://phpdoc.org/) - A documentation generator.
 * [phpDox](https://phpdox.net/) - A documentation generator for PHP projects (that is not limited to API documentation).
 * [zircote/swagger-php](https://github.com/zircote/swagger-php) - Generate OpenAPI documentation for your RESTful API.
 


### PR DESCRIPTION
* Fix to use the official name.
* Remove the version reference. Version 3 was released [four years ago](https://github.com/phpDocumentor/phpDocumentor/releases?page=3).
* Point the link to the official website, not the GH repo.