### PR TITLE
feat: add "CycloneDX Composer Plugin"

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Composer Prefer Lowest Validator](https://github.com/dereuromark/composer-prefer-lowest) - A plugin to check if minimum dependencies can be installed and tested.
 * [Composer Require Checker](https://github.com/maglnet/ComposerRequireChecker) - CLI tool to analyze composer dependencies and verify that no unknown symbols are used in the sources of a package.
 * [Composer Unused](https://github.com/composer-unused/composer-unused) - A CLI Tool to scan for unused composer packages.
+* [CycloneDX Composer Plugin](https://packagist.org/packages/cyclonedx/cyclonedx-php-composer) - A composer plugin to generate your project's Software Bill of Materials (SBOM).
 * [Repman](https://repman.io) - A private PHP package repository manager and Packagist proxy.
 * [Satis](https://github.com/composer/satis) - A static Composer repository generator.
 * [Tooly](https://github.com/tommy-muehle/tooly-composer-script) - A library to manage PHAR files in a project using Composer.


### PR DESCRIPTION
Github: https://github.com/CycloneDX/cyclonedx-php-composer
Packagist: https://packagist.org/packages/cyclonedx/cyclonedx-php-composer

> A plugin for PHP's _[Composer](https://getcomposer.org/)_ that generates Software Bill of Materials (SBOM) in _[CycloneDX](https://cyclonedx.org/)_ format.