### PR TITLE
ci: Update awesomebot.yml to use upload-artifact v4

### DIFF
--- a/.github/workflows/awesomebot.yml
+++ b/.github/workflows/awesomebot.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Run Awesome Bot
       run: awesome_bot README.md --request-delay 1 --allow-dupe --white-list igor.io,symfony,toranproxy.com,vagrantup.com,3v4l.org,voicesoftheelephpant.com,drupal.org,oreilly.com,youtube.com,lumen.laravel.com
     
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: ab-results


### PR DESCRIPTION
It appears this action has been failing for some time:

```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v1`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

There should not be any issues updating the action to version 4.  This PR just makes one change:

```diff
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
```