### PR TITLE
Replace Symfony Security Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 
 * [AntiXSS](https://github.com/voku/anti-xss) - A library that tries to preventing Cross-Site Scripting (XSS) attacks by blacklisting.
 * [Halite](https://paragonie.com/project/halite) - A simple library for encryption using [libsodium](https://github.com/jedisct1/libsodium).
+* [Local PHP Security Checker](https://github.com/fabpot/local-php-security-checker) - A command line tool that checks if your PHP application depends on PHP packages with known security vulnerabilities.
 * [Optimus](https://github.com/jenssegers/optimus) - Id obfuscation based on Knuth's multiplicative hashing method.
 * [OWASP](https://owasp.org/) - Explore the world of cyber security.
 * [PHPGGC](https://github.com/ambionics/phpggc) - A library of PHP unserializable payloads along with a tool to generate them.
@@ -371,7 +372,6 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [random_compat](https://github.com/paragonie/random_compat) - PHP 5.x support for `random_bytes()` and `random_int()`
 * [Roave Security Advisories](https://github.com/Roave/SecurityAdvisories) - This package ensures that your application doesn't have installed dependencies with known security vulnerabilities.
 * [Secure Headers](https://github.com/BePsvPT/secure-headers) - A package that adds security related headers to HTTP response.
-* [Symfony Security Monitoring](https://security.symfony.com/) - A web tool to check your Composer dependencies for security advisories, previously known as "SensioLabs Security Check".
 * [SQLMap](https://github.com/sqlmapproject/sqlmap) - An automatic SQL injection and database takeover tool.
 * [Zap](https://github.com/zaproxy/zaproxy) - An integrated penetration testing tool for web applications.
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Gaufrette](https://github.com/KnpLabs/Gaufrette) - A filesystem abstraction layer.
 * [PHP FFmpeg](https://github.com/PHP-FFmpeg/PHP-FFmpeg/) - A wrapper for the [FFmpeg](https://www.ffmpeg.org/) video library.
 * [UnifiedArchive](https://github.com/wapmorgan/UnifiedArchive) - A unified reader and writer of compressed archives.
-* [Parquet](https://github.com/flow-php/parquet) - PHP implementation of Parquet file format 
+* [Parquet](https://github.com/flow-php/parquet) - PHP implementation of Parquet file format
 
 ### Streams
 *Libraries for working with streams.*

--- a/README.md
+++ b/README.md
@@ -363,7 +363,6 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 
 * [AntiXSS](https://github.com/voku/anti-xss) - A library that tries to preventing Cross-Site Scripting (XSS) attacks by blacklisting.
 * [Halite](https://paragonie.com/project/halite) - A simple library for encryption using [libsodium](https://github.com/jedisct1/libsodium).
-* [Local PHP Security Checker](https://github.com/fabpot/local-php-security-checker) - A command line tool that checks if your PHP application depends on PHP packages with known security vulnerabilities.
 * [Optimus](https://github.com/jenssegers/optimus) - Id obfuscation based on Knuth's multiplicative hashing method.
 * [OWASP](https://owasp.org/) - Explore the world of cyber security.
 * [PHPGGC](https://github.com/ambionics/phpggc) - A library of PHP unserializable payloads along with a tool to generate them.


### PR DESCRIPTION
[Symfony Security Monitoring](https://security.symfony.com)  does not exist anymore.

[Local PHP Security Checker](https://github.com/fabpot/local-php-security-checker) is mentioned in Symfony docs as a tip for CI standalone-tool, see: https://symfony.com/doc/7.3/setup.html#checking-security-vulnerabilities

This PR replaces Symfony Security Monitoring with Local PHP Security Checker.
