### PR TITLE
Add `beeyev/disposable-email-filter-php`

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Stampie](https://github.com/Stampie/Stampie) - A library for email services such as [SendGrid](https://sendgrid.com/en-us), [PostMark](https://postmarkapp.com), [MailGun](https://www.mailgun.com/) and [MailChimp](https://mailchimp.com/features/transactional-email/).
 * [SwiftMailer](https://swiftmailer.symfony.com) - A mailer solution.
 * [Symfony Mailer](https://github.com/symfony/mailer) - A powerful library for creating and sending emails.
+* [Disposable email filter](https://github.com/beeyev/disposable-email-filter-php) - Disposable (temporary/throwaway/fake) email detection library.
 
 ### Files
 *Libraries for file manipulation and MIME type detection.*


### PR DESCRIPTION
Github: https://github.com/beeyev/disposable-email-filter-php
Packagist: https://packagist.org/packages/beeyev/disposable-email-filter-php

> PHP package that detects disposable (temporary/throwaway/fake) email addresses. It is framework-agnostic and has no dependencies, but includes support for Laravel. It validates email addresses to ensure they are genuine, which is useful for managing account sign-ups and assessing the number of legitimate email addresses in your system.
> This tool also helps to avoid communication errors and blocks spam addresses.