### PR TITLE
Replace old PSR-7 middlewares with new PSR-15 middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 ### Middlewares
 *Libraries for building application using middlewares.*
 
-* [PSR-7 Middlewares](https://github.com/oscarotero/psr7-middlewares) - Inspiring collection of handy middlewares.
+* [PSR-15 Middlewares](https://github.com/middlewares/psr15-middlewares) - Inspiring collection of handy middlewares.
 * [Relay](https://github.com/relayphp/Relay.Relay) - A PHP 5.5 PSR-7 middleware dispatcher.
 * [Stack](https://github.com/stackphp) - A library of stackable middleware for Symfony.
 * [Laminas Stratigility](https://github.com/laminas/laminas-stratigility) - Middleware for PHP built on top of PSR-7.


### PR DESCRIPTION
Hi,

As the title says, it replaces the old style of PSR-7 middleware (archived) with the new PSR-15 middleware (by the same author and myself).

Thanks!