### PR TITLE
Add Url highlight library

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,7 @@ Libraries to help manage database schemas and migrations.
 * [SQL Formatter](https://github.com/jdorn/sql-formatter/) - A library for formatting SQL statements.
 * [Stringy](https://github.com/voku/Stringy) - A string manipulation library with multibyte support.
 * [UA Parser](https://github.com/tobie/ua-parser/tree/master/php) - A library for parsing user agent strings.
+* [Url highlight](https://github.com/vstelmakh/url-highlight) - A library for parsing URLs from text and converting them into clickable links.
 * [URLify](https://github.com/jbroadway/urlify) - A PHP port of Django's URLify.js.
 * [UUID](https://github.com/ramsey/uuid) - A library for generating UUIDs.
 


### PR DESCRIPTION
[Url highlight](https://github.com/vstelmakh/url-highlight) - PHP library to parse URLs from string input and convert them into clickable links. Works with complex URLs, edge cases and encoded input.

At first this may look like a trivial task that can be solved by the regex. But with taking into account all the edge cases - it quickly blows up the complexity. For example, this is completely valid URL: `http://elk.example.com:81/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'deve-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'*')),sort:!('@timestamp',desc))`, parsing it from the text would be a chalange, but the library covering this as well as other complex cases. For more details see [examples](https://github.com/vstelmakh/url-highlight/blob/master/docs/examples.md).

Supported PHP versions `7.1 +`