### PR TITLE
Add MockAPI-PHP to the [API] section

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,6 +742,7 @@ Libraries to help manage database schemas and migrations.
 * [Negotiation](https://github.com/willdurand/Negotiation) - A content negotiation library.
 * [Restler](https://github.com/Luracast/Restler) - A lightweight framework to expose PHP methods as RESTful web API.
 * [PackageGenerator](https://github.com/WsdlToPhp/PackageGenerator) - Package Generator generates a PHP SDK from any WSDL.
+* [MockAPI-PHP](https://github.com/ka215/MockAPI-PHP) - A file-based mock API server with dynamic responses, schema validation, and OpenAPI 3.0 schema generation.
 
 ### Caching and Locking
 *Libraries for caching data and acquiring locks.*


### PR DESCRIPTION
This PR adds [MockAPI-PHP](https://github.com/ka215/MockAPI-PHP) to the [API] section.

**MockAPI-PHP** is a lightweight, file-based mock API server built with PHP 8.3+.  
It allows developers to simulate RESTful APIs using `.json` or `.txt` response files — no backend or framework required.

Key features:
- Dynamic endpoints and polling
- Error simulation and response delays
- Simple CLI or browser interface
- Automatic OpenAPI 3.0 schema generation from response data

GitHub: https://github.com/ka215/MockAPI-PHP