### PR TITLE
Update Drupal link to point to the correct homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Backdrop](https://backdropcms.org) - A CMS targeting small-to-medium-sized business and non-profits (a fork of Drupal).
 * [Concrete5](https://www.concretecms.com/) - A CMS targeting users with a minimum of technical skills.
 * [CraftCMS](https://github.com/craftcms/cms) - A flexible, user-friendly CMS for creating custom digital experiences on the web and beyond.
-* [Drupal](https://new.drupal.org/) - An enterprise level CMS.
+* [Drupal](https://new.drupal.org/home) - An enterprise level CMS.
 * [Grav](https://github.com/getgrav/grav) - A modern flat-file CMS.
 * [Joomla](https://www.joomla.org/) - Another leading CMS.
 * [Kirby](https://getkirby.com/) - A flat-file CMS that adapts to any project.


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the URL for the Drupal CMS link to point to the correct homepage.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L153-R153): Updated the Drupal CMS link to `https://new.drupal.org/home` from `https://new.drupal.org/`.