### PR TITLE
Update Symfony link description for clarity [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Laravel Components](https://github.com/illuminate) - The Laravel Framework components.
 * [League of Extraordinary Packages](https://thephpleague.com/) - A PHP package development group.
 * [Spatie Open Source](https://spatie.be/open-source) - A collection of open-source PHP and Laravel packages.
-* [Symfony Components](https://symfony.com/packages) - The components that make Symfony.
+* [Symfony Packages](https://symfony.com/packages) - Decoupled libraries for PHP applications.
 * [Laminas Components](https://docs.laminas.dev/components/) - The components that make the Laminas Framework.
 
 ### Micro Frameworks


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change involves updating the description of the Symfony components link to better reflect its purpose.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L173-R173): Changed the description for the Symfony components link from "The components that make Symfony" to "Decoupled libraries for PHP applications."