### PR TITLE
Add pikaid to Strings section

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@ Libraries to help manage database schemas and migrations.
 * [Jieba-PHP](https://github.com/fukuball/jieba-php) - A PHP port of Python's jieba. Chinese text segmentation for natural language processing.
 * [Mobile-Detect](https://github.com/serbanghita/Mobile-Detect) - A lightweight PHP class for detecting mobile devices (including tablets).
 * [Patchwork UTF-8](https://github.com/nicolas-grekas/Patchwork-UTF8) - A portable library for working with UTF-8 strings.
+* [Pikaid](https://github.com/pikaid/pikaid-php) - A library for generating pikaids (base 26 small, sortable and secure IDs).
 * [Portable ASCII](https://github.com/voku/portable-ascii) - A library to convert strings to ASCII.
 * [Portable UTF-8](https://github.com/voku/portable-utf8) - A string manipulation library with UTF-8 safe replacement methods.
 * [Slugify](https://github.com/cocur/slugify) - A library to convert strings to slugs.


### PR DESCRIPTION
Add [Pikaid](https://github.com/pikaid/pikaid-php) to the Strings section.

Pikaid (pronounced “Pika ID”) is a 26-character, lowercase Base36 identifier designed to be:
  -Small: same length as ULID (26 chars) but more entropy-packed.
  -Sortable: lexicographically ordered by creation timestamp without extra fields.
  -Secure: 96 bits of cryptographic randomness to make collisions practically impossible.
