### PR TITLE
Add Fusio to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,7 @@ Libraries to help manage database schemas and migrations.
 * [API Platform](https://api-platform.com ) - Expose in minutes a hypermedia REST API that embraces JSON-LD, Hydra format.
 * [Laminas API Tool Skeleton](https://github.com/laminas-api-tools/api-tools-skeleton) - An API builder built with the Laminas Framework.
 * [Drest](https://github.com/leedavis81/drest) - A library for exposing Doctrine entities as REST resource endpoints.
+* [Fusio](https://github.com/apioo/fusio) - An open-source API management platform.
 * [HAL](https://github.com/blongden/hal) - A Hypertext Application Language (HAL) builder library.
 * [Hateoas](https://github.com/willdurand/Hateoas) - A HATEOAS REST web service library.
 * [Jane](https://github.com/janephp/janephp/) - An OpenApi client generator with validation support.


### PR DESCRIPTION
This PR adds Fusio to the API category, an interesting tool to build APIs.

GitHub: https://github.com/apioo/fusio
Website: https://www.fusio-project.org/
