### PR TITLE
Add Djot parser to the list of Markup parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,7 @@ Libraries to help manage database schemas and migrations.
 * [Cebe Markdown](https://github.com/cebe/markdown) - A fast and extensible Markdown parser.
 * [CommonMark PHP](https://github.com/thephpleague/commonmark) - Highly-extensible Markdown parser which fully supports the [CommonMark spec](https://spec.commonmark.org/).
 * [Decoda](https://github.com/milesj/decoda) - A lightweight markup parser library.
+* [Djot](https://github.com/php-collective/djot-php) - A PHP parser for [Djot](https://djot.net/), a modern light markup language (successor of Markdown).
 * [Essence](https://github.com/essence/essence) - A library for extracting web media.
 * [Embera](https://github.com/mpratt/Embera) - An Oembed consumer library.
 * [HTML to Markdown](https://github.com/thephpleague/html-to-markdown) - Converts HTML into Markdown.


### PR DESCRIPTION
 => https://github.com/php-collective/djot-php
 
I don't often contribute a library myself.
I think this one is worth it :)

Also now officially included in PHPStorm and Jetbrains IDEs and available for https://github.com/phpDocumentor/ as well as WP as replacement/upgrade from markdown(extra).

More powerful and twice as fast as the markdown equivalents.