### PR TITLE
Add Sidemail to Email section

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Mautic](https://github.com/mautic/mautic) - Email marketing automation
 * [PHPMailer](https://github.com/PHPMailer/PHPMailer) - Another mailer solution.
 * [PHP IMAP](https://github.com/barbushin/php-imap) - A library to access mailboxes via POP3, IMAP and NNTP.
+* [Sidemail](https://github.com/sidemail/sidemail-sdk-php) – Email API + PHP SDK for sending and managing application emails.
 * [Stampie](https://github.com/Stampie/Stampie) - A library for email services such as [SendGrid](https://sendgrid.com/en-us), [PostMark](https://postmarkapp.com), [MailGun](https://www.mailgun.com/) and [MailChimp](https://mailchimp.com/features/transactional-email/).
 * [SwiftMailer](https://swiftmailer.symfony.com/docs/introduction.html) - A mailer solution.
 * [Symfony Mailer](https://github.com/symfony/mailer) - A powerful library for creating and sending emails.


### PR DESCRIPTION
Added Sidemail (email API + PHP SDK for sending and managing application emails) to the Email section.

Github: https://github.com/sidemail/sidemail-sdk-php
Website docs: https://sidemail.io/docs/send-emails-with-php/