### PR TITLE
Add Open Food Facts Laravel wrapper to Third Party APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,7 @@ Libraries to help manage database schemas and migrations.
 * [Campaign Monitor](https://campaignmonitor.github.io/createsend-php/) - The official Campaign Monitor PHP library.
 * [Github](https://github.com/KnpLabs/php-github-api) - A library to interface with the Github API.
 * [Mailgun](https://github.com/mailgun/mailgun-php) The official Mailgun PHP API.
+* [Open Food Facts](https://github.com/openfoodfacts/openfoodfacts-laravel) - A Laravel wrapper for the Open Food Facts API, enabling product lookups across food, beauty, and pet food databases.
 * [Square](https://github.com/square/connect-php-sdk) - The official Square PHP SDK for payments and other Square APIs.
 * [Stripe](https://github.com/stripe/stripe-php) - The official Stripe PHP library.
 * [Twilio](https://github.com/twilio/twilio-php) - The official Twilio PHP REST API.


### PR DESCRIPTION
## Add openfoodfacts/openfoodfacts-laravel to Third Party APIs

[Open Food Facts](https://github.com/openfoodfacts/openfoodfacts-laravel) is the official Laravel wrapper for the Open Food Facts API, maintained by the Open Food Facts organisation.

**Why it belongs here:**
- Composer-installable: `composer require openfoodfacts/openfoodfacts-laravel`
- Supports PHP 8.1+, Laravel 9.x / 10.x / 11.x
- 183 GitHub stars, MIT licence, actively maintained (last release August 2025, updated February 2026)
- Includes a PHPUnit test suite with Scrutinizer CI integration
- Documented in English with usage examples
- Fills a genuine gap in the Third Party APIs section: no food/nutrition data API is currently listed

The entry follows the existing format, ends with a period, and is inserted in alphabetical order (between Mailgun and Square).