### PR TITLE
Add grpc-php-rs to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ Libraries to help manage database schemas and migrations.
 * [BotMan](https://github.com/botman/botman) - A framework agnostic PHP library to build cross-platform chatbots.
 * [ClassPreloader](https://github.com/ClassPreloader/ClassPreloader) - A library for optimizing autoloading.
 * [Ganesha](https://github.com/ackintosh/ganesha) - A PHP implementation of Circuit Breaker pattern.
+* [grpc-php-rs](https://github.com/BSN4/grpc-php-rs) - A drop-in replacement for ext-grpc built in Rust. Fixes ZTS crashes and OpenSSL conflicts.
 * [Hprose-PHP](https://github.com/hprose/hprose-php) - A cross-language RPC.
 * [Laravel Serializable Closure](https://github.com/laravel/serializable-closure) - A library that allows Closures to be serialized.
 * [noCAPTCHA](https://github.com/ARCANEDEV/noCAPTCHA) - Helper for Google's noCAPTCHA (reCAPTCHA).


### PR DESCRIPTION
Adds [grpc-php-rs](https://github.com/BSN4/grpc-php-rs) — a drop-in replacement for ext-grpc built in Rust. Fixes the ZTS/TSRM crashes and OpenSSL/BoringSSL conflicts that affect FrankenPHP, Swoole, and other threaded PHP runtimes.

Same `Grpc\` namespace API, no code changes needed. Pre-built binaries for PHP 8.2–8.5 via PIE.