### PR TITLE
Add Anthropic PHP and Anthropic for Laravel to LLMs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,6 +812,8 @@ Libraries to help manage database schemas and migrations.
 ### LLMs
 *Libraries for working with Large Language Models.*
 
+* [Anthropic](https://github.com/mozex/anthropic-php) - A PHP client for the Anthropic API, supporting messages, streaming, tool use, and batch processing.
+* [Anthropic for Laravel](https://github.com/mozex/anthropic-laravel) - A Laravel wrapper for the Anthropic PHP client with Facades, config publishing, and testing fakes.
 * [Instructor for PHP](https://github.com/cognesy/instructor-php) - Structured data outputs with LLMs, in PHP.
 * [LLPhant](https://github.com/LLPhant/LLPhant) - A comprehensive PHP Generative AI Framework using OpenAI GPT 4. Inspired by Langchain.
 * [OpenAI Client](https://github.com/openai-php/client) - OpenAI PHP is a supercharged community-maintained PHP API client that allows you to interact with OpenAI API.


### PR DESCRIPTION
Adding the community PHP clients for the Anthropic (Claude) AI API to the LLMs section. anthropic-php has 337K+ downloads and anthropic-laravel has 212K+ downloads on Packagist — filling the gap alongside the existing OpenAI and Mistral entries.