### PR TITLE
Add ReleaseRun Composer Package Health checker to Dependency Management Extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Pickle](https://github.com/FriendsOfPHP/pickle) - A PHP extension installer.
 
 ### Dependency Management Extras
+* [ReleaseRun Composer Package Health](https://releaserun.com/tools/composer-package-health/) - A free web tool that checks any Composer package for abandonment status, latest version, and maintenance activity. Gives an instant A–F health grade.
 *Extras related to dependency management.*
 
 * [Composed](https://github.com/joshdifabio/composed) - A library to parse your project's Composer environment at runtime.


### PR DESCRIPTION
Adds a free web-based tool for checking PHP Composer package health — latest version, abandonment status, maintenance activity, and A–F grade. Useful for auditing dependencies before `composer require`.

URL: https://releaserun.com/tools/composer-package-health/