### PR TITLE
Add DDLess to Debugging and Profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 
 * [APM](https://pecl.php.net/package/APM) - Monitoring extension collecting errors and statistics into SQLite/MySQL/StatsD.
 * [Barbushin PHP Console](https://github.com/barbushin/php-console) - Another web debugging console using Google Chrome.
+* [DDLess](https://ddless.com) - A desktop PHP debugger that provides step debugging via AST instrumentation without requiring extensions or IDE plugins.
 * [Kint](https://github.com/kint-php/kint) - A debugging and profiling tool.
 * [Metrics](https://github.com/beberlei/metrics) - A simple metrics API library.
 * [PCOV](https://github.com/krakjoe/pcov) - A self-contained code coverage compatible driver.


### PR DESCRIPTION
DDLess is a desktop PHP debugger that uses AST-based code instrumentation (via nikic/PHP-Parser) to provide step debugging, breakpoints, variable inspection, and call stack navigation, without requiring PHP extensions, Composer packages, or IDE plugins.
Why it fits the list:

Unique in its approach: The only PHP step debugger that works without a C extension. It uses AST parsing and file-based IPC instead of the socket-based approach used by Xdebug.
Fills a niche gap: Addresses the well-documented friction of configuring Xdebug across Docker, WSL, and SSH environments.
Targets supported PHP versions: PHP 7.4 through 8.4, tested via CI.
Actively maintained and documented: English documentation at [ddless.com/docs](https://ddless.com/docs), engine source available at [github.com/behindSolution/ddless-engine](https://github.com/behindSolution/ddless-engine) with automated tests across PHP 7.4–8.4.

Works with Laravel, WordPress, Symfony, Drupal, CakePHP, Slim, and any PHP 7.4+ project. Available for Windows, macOS (Intel + Apple Silicon), and Linux.
Disclosure: I am the author of DDLess.