### PR TITLE
Add skipper-php

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [PHPUnit](https://github.com/sebastianbergmann/phpunit) - A unit testing framework.
 * [PHPUnit Polyfills](https://github.com/Yoast/PHPUnit-Polyfills/) - Simplifies running PHPUnit tests on multiple PHPUnit versions.
 * [Prophecy](https://github.com/phpspec/prophecy) - A highly opinionated mocking framework.
+* [skipper-php](https://github.com/get-skipper/skipper-php) - Real-time test execution control via Google Spreadsheet, enabling instant toggle without code changes.
 * [VFS Stream](https://github.com/bovigo/vfsStream) - A virtual filesystem stream wrapper for testing.
 
 ### Continuous Integration


### PR DESCRIPTION
Add [skipper-php](https://github.com/get-skipper/skipper-php) to the Testing section.

Skipper gives teams real-time control over test execution via a shared Google Spreadsheet — enabling instant enable/disable without code changes, PRs, or deployments.

- MIT license
- GitHub: https://github.com/get-skipper/skipper-php