### PR TITLE
Replace unmaintained yosymfony/toml with php-collective/toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,7 +807,7 @@ Libraries to help manage database schemas and migrations.
 
 * [PHP Dotenv](https://github.com/vlucas/phpdotenv) - Parse and load environment variables from `.env` files.
 * [Symfony Dotenv](https://github.com/symfony/dotenv)- Parse and load environment variables from `.env` files.
-* [PHP Toml](https://github.com/php-collective/toml) - A TOML parser and encoder with AST access and error recovery.
+* [Toml](https://github.com/php-collective/toml) - A TOML parser and encoder with AST access and error recovery.
 
 ### LLMs
 *Libraries for working with Large Language Models.*


### PR DESCRIPTION
The current TOML library [yosymfony/toml](https://github.com/yosymfony/toml) has not received any commits since August 2020 (~6 years). 
TOML <= 0.4

Replacing it with [php-collective/toml](https://github.com/php-collective/toml) which is actively maintained and offers:

- TOML 1.0 and 1.1 support
- Both parsing and encoding
- AST access for tooling
- Error recovery with collected parse errors
- PHP 8.2+ with modern features