### PR TITLE
Add Tapix - CSV Import Wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [PHPWord](https://github.com/PHPOffice/PHPWord) - A library for working with Microsoft Word documents.
 * [PHPSpreadsheet](https://github.com/PHPOffice/PhpSpreadsheet) - A pure PHP library for reading and writing spreadsheet files (successor of PHPExcel).
 * [OpenSpout](https://github.com/openspout/openspout) - A community driven fork of `box/spout`, a PHP library to read and write spreadsheet files (CSV, XLSX and ODS), in a fast and scalable way.
+* [Tapix](https://tapix.dev) - A CSV import wizard with smart column mapping, inline validation, relationship linking, and queue-powered processing.
 ### Database
 *Libraries for interacting with databases using object-relational mapping (ORM) or datamapping techniques.*
 


### PR DESCRIPTION
Tapix is a drop-in CSV import wizard for PHP/Laravel applications. It provides a 4-step guided flow: upload, column mapping, inline validation and review, and queue-powered background processing. Supports relationship linking (BelongsTo, MorphToMany), multi-tenancy, and first-class Filament integration.

Website: https://tapix.dev