### PR TITLE
Update Deptrac URL to active repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 *Libraries for performing static analysis of PHP code.*
 
 * [Dead Code Detector](https://github.com/shipmonk-rnd/dead-code-detector) - A PHPStan extension for finding unused PHP code.
-* [Deptrac](https://github.com/qossmic/deptrac) - A static analysis tool for enforcing dependency rules between architectural layers.
+* [Deptrac](https://github.com/deptrac/deptrac) - A static analysis tool for enforcing dependency rules between architectural layers.
 * [Exakat](https://github.com/exakat/exakat) - A static analysis engine for PHP.
 * [Larastan](https://github.com/larastan/larastan) - A PHPStan wrapper for Laravel that adds static analysis to Laravel projects.
 * [Mago](https://github.com/carthage-software/mago) - A toolchain for PHP that aims to improve the developer experience.


### PR DESCRIPTION
## Summary

The [`qossmic/deptrac`](https://github.com/qossmic/deptrac) repository was [archived](https://github.com/qossmic/deptrac) on 2026-02-17. The project moved to [`deptrac/deptrac`](https://github.com/deptrac/deptrac), which is actively maintained (v4.6.0 released 2026-02-02, ~60 releases).

## Context

Deptrac was removed from the list in #1402 ("Remove 21 unmaintained/archived libraries") on 2026-03-26, but was re-added in the "tidying up" commit 11 days later (bcbd70c) with the stale `qossmic/deptrac` URL — most likely because the tool genuinely is worth listing, just not at that URL.

Since the `deptrac/deptrac` project meets the usual criteria (established, actively maintained, Composer-installable), the minimal fix is to point the existing entry at the active repo rather than drop it again.

## Change

`https://github.com/qossmic/deptrac` → `https://github.com/deptrac/deptrac`

No description or alphabetical-position changes.