### PR TITLE
feat: add TWZRD Agent Intel MCP server to API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,6 +731,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [Negotiation](https://github.com/willdurand/Negotiation) - A content negotiation library.
 * [Restler](https://github.com/Luracast/Restler) - A lightweight framework to expose PHP methods as RESTful web API.
 * [PackageGenerator](https://github.com/WsdlToPhp/PackageGenerator) - Package Generator generates a PHP SDK from any WSDL.
+* [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring MCP server for AI agents on Solana. Verify agent wallet identity before x402 micropayments. Free MCP endpoint available.
 
 ### Caching and Locking
 *Libraries for caching data and acquiring locks.*


### PR DESCRIPTION
## What this adds

[TWZRD Agent Intel](https://intel.twzrd.xyz) — a trust scoring MCP server for AI agents operating on Solana.

**What it does**: Provides on-chain trust scores for AI agent wallets. Before sending x402 micropayments to an AI agent, you can query its wallet history, activity patterns, and trust score. Free MCP endpoint.

**MCP config**:
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

**Why it belongs in the API section**: It's a REST + MCP API for identity/trust verification of autonomous agents — fits alongside other authentication and identity APIs in this section.

**Checklist**:
- [x] Entry added in alphabetical order within section (after PackageGenerator, before Caching)
- [x] Format: `* [Name](url) - Description.`
- [x] Short, descriptive description without marketing taglines
- [x] Project is live and maintained