### PR TITLE
Update GitHub Actions to use latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Link Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check links
         uses: lycheeverse/lychee-action@v2
@@ -36,7 +36,7 @@ jobs:
             README.md
           fail: true
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: lychee-results


### PR DESCRIPTION
Bumps `actions/checkout` to v6 and `actions/upload-artifact` to v7.