### PR TITLE
Add sqlc-php

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 * [RedBean](https://redbeanphp.com/index.php) - A lightweight, configuration-less ORM.
 * [Slimdump](https://github.com/webfactory/slimdump) - An easy dumper tool for MySQL.
 * [Spot2](https://github.com/spotorm/spot2) - A MySQL datamapper ORM.
+* [Sqlc-php](https://github.com/phpibe/sqlc-php) - Compile SQL to type-safe code.
 
 ### Migrations
 *Libraries to help manage database schemas and migrations.*


### PR DESCRIPTION
## Description

A PHP code generator inspired by [sqlc](https://sqlc.dev/) for Go. It reads your SQL schema and annotated query files, and generates fully-typed PHP 8.4 classes that use PDO under the hood — no ORM, no magic, just plain objects derived directly from your database.

## Project links

- Repository: https://github.com/phpibe/sqlc-php
- Packagist: https://packagist.org/packages/phpibe/sqlc-php
- Documentation: https://phpibe.github.io/sqlc-php

## Quality checklist

- [x] PHP `^8.3` (supported version)
- [x] Composer installable: `composer require phpibe/sqlc-php`
- [x] PSR-4 autoload under `Sqlc\` namespace
- [x] Tested with PHPUnit 11
- [x] Actively maintained
- [x] Documented in English (README + dedicated docs site)
- [x] MIT licensed

## PR checklist (per CONTRIBUTING.md)

- [x] Format: `[LIBRARY](LINK) - DESCRIPTION.` with full stop
- [x] Description is short, clear, unbiased, no jargon
- [x] Spelling and grammar checked
- [x] Entry added alphabetically (between `Brick Money` and `OmniPay`)
- [x] Composer installable
- [x] Active and maintained

## The added line

```
* [Sqlc-php](https://github.com/phpibe/sqlc-php) - Compile SQL to type-safe code.
```