### PR TITLE
Add Carve to Markup and CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ Please see [CONTRIBUTING](https://github.com/ziadoz/awesome-php/blob/master/CONT
 ### Markup and CSS
 *Libraries for working with markup and CSS formats.*
 
+* [Carve](https://github.com/markup-carve/carve-php) - A PHP parser for [Carve](https://markup-carve.github.io/carve/), a lightweight markup language derived from Markdown and Djot.
 * [Cebe Markdown](https://github.com/cebe/markdown) - A fast and extensible Markdown parser.
 * [CommonMark PHP](https://github.com/thephpleague/commonmark) - Highly-extensible Markdown parser which fully supports the [CommonMark spec](https://spec.commonmark.org/).
 * [Decoda](https://github.com/milesj/decoda) - A lightweight markup parser library.


### PR DESCRIPTION
Adds Carve to the Markup and CSS category.

Project: https://github.com/markup-carve/carve-php (Packagist: `markup-carve/carve-php`)
Language site: https://markup-carve.github.io/carve/

Carve is a lightweight markup language derived from Markdown and Djot, with a written specification and a conformance corpus that three independent engines (PHP, JavaScript, Rust) are tested against. The PHP package is a standalone parser and renderer: no dependencies beyond PHP 8.2, PSR-12, PHPStan level max, semantically versioned, MIT.

Entry placed alphabetically, ahead of Cebe Markdown.
